### PR TITLE
Refine hero and highlight best sellers

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,10 @@
 import Link from 'next/link'
+import { PackageCheck, ShieldCheck, LockKeyhole } from 'lucide-react'
 import Hero from '@/components/Hero'
 import { allProducts } from '@/lib/products'
+import CategoryCarousel from '@/components/home/CategoryCarousel'
+import BestSellers from '@/components/home/BestSellers'
+import TrustBadgesStrip from '@/components/home/TrustBadgesStrip'
 
 const categoryLabels: Record<string, string> = {
   bienestar: 'Bienestar intimo',
@@ -12,6 +16,7 @@ const categoryLabels: Record<string, string> = {
   munecas: 'Muñecas realistas',
   anales: 'Juegos anales'
 }
+
 const featuredCategories = ['bienestar', 'lenceria', 'kits'] as const
 
 function labelFor(slug: string) {
@@ -22,45 +27,79 @@ function labelFor(slug: string) {
     .join(' ')
 }
 
-export default function Page(){
+const TRUST_BADGES = [
+  {
+    label: 'Envío discreto 100%',
+    description: 'Empaques neutros y seguimiento privado sin revelar contenidos.',
+    icon: <PackageCheck className="h-5 w-5" aria-hidden />
+  },
+  {
+    label: 'Pago seguro',
+    description: 'Pasarelas encriptadas y múltiples métodos sin cargos ocultos.',
+    icon: <ShieldCheck className="h-5 w-5" aria-hidden />
+  },
+  {
+    label: 'Atención confidencial',
+    description: 'Consultoría anónima por chat y recomendaciones personalizadas.',
+    icon: <LockKeyhole className="h-5 w-5" aria-hidden />
+  }
+]
+
+export default function Page() {
   const products = allProducts()
   const catalogCategories = Array.from(new Set(products.map(p => p.category)))
-  const otherCategories = catalogCategories.filter(slug => !featuredCategories.includes(slug as typeof featuredCategories[number]))
+  const featuredSet = new Set<string>(featuredCategories)
+  const featured = featuredCategories.filter(slug => catalogCategories.includes(slug))
+  const otherCategories = catalogCategories.filter(slug => !featuredSet.has(slug))
   const nsfwCategories = new Set(products.filter(p => p.nsfw).map(p => p.category))
+  const orderedCategories = [...featured, ...otherCategories]
+  const categoriesForCarousel = orderedCategories.map(slug => ({
+    slug,
+    label: labelFor(slug),
+    isSensitive: nsfwCategories.has(slug)
+  }))
+  const bestSellers = products.filter(product => product.bestSeller)
 
   return (
     <>
       <Hero />
-      <section className="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6">
-        {featuredCategories.map(slug => (
-          <Link key={slug} href={`/categoria/${slug}`} className="block p-5 md:p-6 rounded-2xl border hover:shadow-md transition">
-            <div className="text-base md:text-lg font-medium">{labelFor(slug)}</div>
-            <div className="text-sm text-neutral-600 mt-1">Explorar</div>
-          </Link>
-        ))}
-      </section>
-
-      {otherCategories.length > 0 && (
-        <section className="mt-8">
-          <h2 className="text-lg font-semibold text-neutral-800 mb-3">Catálogo completo</h2>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6">
-            {otherCategories.map(slug => {
-              const label = labelFor(slug)
-              const isSensitive = nsfwCategories.has(slug)
-              return (
-                <Link
-                  key={slug}
-                  href={`/categoria/${slug}`}
-                  className="block p-5 md:p-6 rounded-2xl border hover:shadow-md transition space-y-1"
-                >
-                  <div className="text-base md:text-lg font-medium">{label}</div>
-                  <div className="text-sm text-neutral-600">{isSensitive ? 'Contenido sensible (18+)' : 'Explorar'}</div>
-                </Link>
-              )
-            })}
-          </div>
-        </section>
-      )}
+      <div className="mt-6 space-y-6">
+        <TrustBadgesStrip badges={TRUST_BADGES} />
+        <CategoryCarousel
+          title="Explora por categoría"
+          subtitle="Mobile-first con desliz lateral — arrastra para descubrir más."
+          categories={categoriesForCarousel}
+        />
+      </div>
+      <div className="mt-10 space-y-10">
+        <BestSellers products={bestSellers} />
+        {otherCategories.length > 0 && (
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold text-neutral-900">¿Buscas algo más específico?</h2>
+            <p className="text-sm text-neutral-600">
+              Recorre las categorías sensibles y temáticas creadas para diferentes niveles de experiencia.
+            </p>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {otherCategories.map(slug => {
+                const label = labelFor(slug)
+                const isSensitive = nsfwCategories.has(slug)
+                return (
+                  <Link
+                    key={slug}
+                    href={`/categoria/${slug}`}
+                    className="block rounded-2xl border border-neutral-200 bg-white/90 p-5 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+                  >
+                    <div className="text-base font-semibold text-neutral-900">{label}</div>
+                    <div className="mt-2 text-sm text-neutral-600">
+                      {isSensitive ? 'Contenido sensible (18+)' : 'Explorar con seguridad'}
+                    </div>
+                  </Link>
+                )
+              })}
+            </div>
+          </section>
+        )}
+      </div>
     </>
   )
 }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,12 +1,68 @@
-﻿'use client'
-import { motion } from 'framer-motion'
-export default function Hero(){
+'use client'
+
+import Link from 'next/link'
+import { motion, type Variants } from 'framer-motion'
+
+const headlineVariants: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 }
+}
+
+const copyVariants: Variants = {
+  hidden: { opacity: 0, y: 12 },
+  visible: { opacity: 1, y: 0 }
+}
+
+export default function Hero() {
   return (
-    <section className="rounded-2xl bg-gradient-to-r from-brand-primary/5 to-brand-accent/5 p-6 md:p-8 mb-6 md:mb-8">
-      <motion.div initial={{opacity:0,y:10}} animate={{opacity:1,y:0}} transition={{duration:0.4}}>
-        <h1 className="text-2xl md:text-3xl font-semibold">Bienvenido — Piloto seguro</h1>
-      </motion.div>
-      <p className="mt-2 text-neutral-600 text-sm md:text-base">Mobile-first, contenido apto para Ads. Imágenes sensibles fuera de indexación.</p>
+    <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-brand-primary/10 via-white to-brand-accent/10 p-6 sm:p-10 md:p-14">
+      <div className="absolute inset-0">
+        <div className="absolute inset-0 bg-[url('/textures/hero-texture.svg')] bg-cover opacity-50 mix-blend-overlay" aria-hidden />
+        <div className="absolute inset-0 bg-gradient-to-br from-brand-primary/15 via-transparent to-brand-accent/30" aria-hidden />
+      </div>
+
+      <div className="relative z-10 flex flex-col gap-10 md:flex-row md:items-center md:justify-between">
+        <div className="max-w-2xl">
+          <motion.div
+            initial="hidden"
+            animate="visible"
+            variants={headlineVariants}
+            transition={{ duration: 0.6, ease: 'easeOut' }}
+          >
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-primary/90">Confianza real, placer privado</p>
+            <h1 className="mt-4 text-3xl font-semibold leading-tight text-neutral-900 sm:text-4xl md:text-[2.9rem] md:leading-[1.05]">
+              Tu intimidad es prioridad: experiencias premium con envíos ultra discretos
+            </h1>
+          </motion.div>
+        </div>
+
+        <div className="max-w-md space-y-6 text-neutral-700">
+          <motion.div
+            initial="hidden"
+            animate="visible"
+            variants={copyVariants}
+            transition={{ delay: 0.2, duration: 0.6, ease: 'easeOut' }}
+          >
+            <div className="space-y-6">
+              <p className="text-base leading-relaxed md:text-lg">
+                Compra desde casa con asesoría segura y pagos protegidos. Cada pedido viaja en embalaje sin marcas y con seguimiento privado para que solo tú sepas lo que llega.
+              </p>
+              <div className="flex flex-wrap gap-3 text-sm">
+                <span className="rounded-full bg-white/70 px-4 py-2 font-medium text-neutral-900 shadow-sm">Soporte 24/7 confidencial</span>
+                <span className="rounded-full bg-white/50 px-4 py-2 font-medium text-neutral-900 shadow-sm">Facturación anónima</span>
+              </div>
+              <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+                <Link
+                  href="#catalogo"
+                  className="inline-flex items-center justify-center rounded-full bg-brand-primary px-6 py-3 text-base font-semibold text-white shadow-lg shadow-brand-primary/30 transition"
+                >
+                  Explorar catálogo seguro
+                </Link>
+              </motion.div>
+            </div>
+          </motion.div>
+        </div>
+      </div>
     </section>
   )
 }

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,11 +1,34 @@
-﻿import Link from 'next/link'
+import Link from 'next/link'
+import type { Product } from '@/lib/products'
 
-export default function ProductCard({ p }: { p: { slug: string; name: string; price: number } }) {
+const BADGE_LABELS: Record<NonNullable<Product['badge']>, string> = {
+  nuevo: 'Nuevo',
+  top: 'Top',
+  promo: 'Promo'
+}
+
+type ProductCardProps = {
+  p: Pick<Product, 'slug' | 'name' | 'price' | 'badge'>
+  highlightBadge?: string
+}
+
+export default function ProductCard({ p, highlightBadge }: ProductCardProps) {
+  const displayBadge = highlightBadge ?? (p.badge ? BADGE_LABELS[p.badge] : undefined)
+
   return (
-    <Link href={`/producto/${p.slug}`} className="block border rounded-2xl p-4 hover:shadow-md transition">
-      <div className="aspect-[4/3] rounded-xl bg-neutral-100 overflow-hidden" aria-hidden />
-      <div className="mt-3 font-medium line-clamp-2">{p.name}</div>
-      <div className="text-brand-primary font-semibold">S/ {p.price.toFixed(2)}</div>
+    <Link href={`/producto/${p.slug}`} className="group block rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+      <div className="relative aspect-[4/3] overflow-hidden rounded-xl bg-neutral-100">
+        <div className="absolute inset-0 bg-gradient-to-br from-brand-primary/10 via-transparent to-brand-accent/20 opacity-0 transition group-hover:opacity-100" aria-hidden />
+        {displayBadge && (
+          <div className="absolute left-3 top-3 inline-flex items-center rounded-full bg-neutral-900/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white shadow-lg">
+            {displayBadge}
+          </div>
+        )}
+      </div>
+      <div className="mt-3 space-y-1">
+        <div className="font-medium text-neutral-900 line-clamp-2">{p.name}</div>
+        <div className="text-brand-primary font-semibold">S/ {p.price.toFixed(2)}</div>
+      </div>
     </Link>
   )
 }

--- a/components/home/BestSellers.tsx
+++ b/components/home/BestSellers.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import Link from 'next/link'
+import { motion, type Variants } from 'framer-motion'
+import type { Product } from '@/lib/products'
+import ProductCard from '@/components/ProductCard'
+
+type BestSellersProps = {
+  products: Product[]
+}
+
+const sectionVariants: Variants = {
+  hidden: { opacity: 0, y: 30 },
+  visible: { opacity: 1, y: 0 }
+}
+
+export default function BestSellers({ products }: BestSellersProps) {
+  if (!products.length) return null
+
+  return (
+    <section className="space-y-6">
+      <motion.div
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, amount: 0.3 }}
+        variants={sectionVariants}
+        transition={{ duration: 0.5, ease: 'easeOut' }}
+      >
+        <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-neutral-900">Más vendidos</h2>
+            <p className="text-sm text-neutral-600">Selección curada por preferencia de la comunidad y disponibilidad inmediata.</p>
+          </div>
+          <Link href="/categoria/bienestar" className="text-sm font-semibold text-brand-primary hover:underline">
+            Ver catálogo completo
+          </Link>
+        </div>
+      </motion.div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {products.map((product, index) => (
+          <motion.div
+            key={product.slug}
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.2 }}
+            transition={{ delay: index * 0.05, duration: 0.4, ease: 'easeOut' }}
+          >
+            <ProductCard p={product} highlightBadge={product.bestSeller ? 'Best Seller' : undefined} />
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/home/CategoryCarousel.tsx
+++ b/components/home/CategoryCarousel.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import Link from 'next/link'
+import { motion, type Variants } from 'framer-motion'
+
+type CategoryItem = {
+  slug: string
+  label: string
+  description?: string
+  isSensitive?: boolean
+}
+
+type DragBounds = { left: number; right: number }
+
+type CategoryCarouselProps = {
+  title?: string
+  subtitle?: string
+  categories: CategoryItem[]
+}
+
+const cardVariants: Variants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: (index: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: { delay: index * 0.05, duration: 0.4, ease: 'easeOut' }
+  })
+}
+
+const MotionTrack = motion.div as any
+
+const MotionCard = motion.div as any
+
+export default function CategoryCarousel({ title, subtitle, categories }: CategoryCarouselProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const trackRef = useRef<HTMLDivElement>(null)
+  const [dragConstraints, setDragConstraints] = useState<DragBounds>({ left: 0, right: 0 })
+
+  const computedCategories = useMemo(() => categories.map(category => ({
+    ...category,
+    description:
+      category.description ?? (category.isSensitive ? 'Contenido sensible (18+)' : 'Explorar con seguridad')
+  })), [categories])
+
+  useEffect(() => {
+    function updateBounds() {
+      const container = containerRef.current
+      const track = trackRef.current
+      if (!container || !track) return
+      const maxOffset = track.scrollWidth - container.offsetWidth
+      setDragConstraints({ left: -Math.max(0, maxOffset), right: 0 })
+    }
+
+    updateBounds()
+    window.addEventListener('resize', updateBounds)
+    return () => window.removeEventListener('resize', updateBounds)
+  }, [computedCategories])
+
+  return (
+    <section className="space-y-4" id="catalogo">
+      {title && (
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold text-neutral-900">{title}</h2>
+          {subtitle && <p className="text-sm text-neutral-600">{subtitle}</p>}
+        </div>
+      )}
+      <div ref={containerRef} className="overflow-hidden">
+        <MotionTrack
+          ref={trackRef}
+          className="flex gap-4 pb-2"
+          drag="x"
+          dragConstraints={dragConstraints}
+          dragElastic={0.12}
+        >
+          {computedCategories.map((category, index) => (
+            <MotionCard
+              key={category.slug}
+              custom={index}
+              initial="hidden"
+              animate="visible"
+              variants={cardVariants}
+              className="min-w-[220px] max-w-[240px] flex-1"
+            >
+              <Link
+                href={`/categoria/${category.slug}`}
+                className="block h-full rounded-2xl border border-neutral-200 bg-white/90 p-5 shadow-sm shadow-neutral-200/60 transition hover:-translate-y-1 hover:shadow-lg"
+              >
+                <div className="text-base font-semibold text-neutral-900">{category.label}</div>
+                <div className="mt-2 text-sm text-neutral-600">{category.description}</div>
+              </Link>
+            </MotionCard>
+          ))}
+        </MotionTrack>
+      </div>
+      <div className="hidden gap-4 md:grid md:grid-cols-3">
+        {computedCategories.map(category => (
+          <Link
+            key={category.slug}
+            href={`/categoria/${category.slug}`}
+            className="block rounded-2xl border border-neutral-200 bg-white/90 p-5 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+          >
+            <div className="text-base font-semibold text-neutral-900">{category.label}</div>
+            <div className="mt-2 text-sm text-neutral-600">{category.description}</div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/components/home/TrustBadgesStrip.tsx
+++ b/components/home/TrustBadgesStrip.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import type { ReactNode } from 'react'
+
+type TrustBadge = {
+  label: string
+  description?: string
+  icon?: ReactNode
+}
+
+type TrustBadgesStripProps = {
+  badges: TrustBadge[]
+}
+
+const MotionBadge = motion.div as any
+
+export default function TrustBadgesStrip({ badges }: TrustBadgesStripProps) {
+  if (!badges.length) return null
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-3">
+      {badges.map((badge, index) => (
+        <MotionBadge
+          key={badge.label}
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: index * 0.08, duration: 0.35, ease: 'easeOut' }}
+          className="flex items-center gap-3 rounded-2xl border border-neutral-200 bg-white/80 px-4 py-3 shadow-sm backdrop-blur"
+        >
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-primary/10 text-brand-primary">
+            {badge.icon}
+          </div>
+          <div>
+            <div className="text-sm font-semibold text-neutral-900">{badge.label}</div>
+            {badge.description && <p className="text-xs text-neutral-600">{badge.description}</p>}
+          </div>
+        </MotionBadge>
+      ))}
+    </div>
+  )
+}

--- a/data/products.json
+++ b/data/products.json
@@ -13,7 +13,9 @@
       "waterproof": "No informado (valor por defecto)",
       "peso": "No especificado (valor por defecto)",
       "garantia": "Garantía limitada de 1 año por defecto de fabricación (valor por defecto)"
-    }
+    },
+    "bestSeller": true,
+    "badge": "top"
   },
   {
     "slug": "gel-silicona-50",
@@ -93,7 +95,9 @@
       "waterproof": "No informado (valor por defecto)",
       "peso": "No especificado (valor por defecto)",
       "garantia": "Garantía limitada de 1 año por defecto de fabricación (valor por defecto)"
-    }
+    },
+    "bestSeller": true,
+    "badge": "nuevo"
   },
   {
     "slug": "lenceria-roja-encaje",
@@ -157,7 +161,9 @@
       "waterproof": "No informado (valor por defecto)",
       "peso": "No especificado (valor por defecto)",
       "garantia": "Garantía limitada de 1 año por defecto de fabricación (valor por defecto)"
-    }
+    },
+    "bestSeller": true,
+    "badge": "top"
   },
   {
     "slug": "kit-aniversario",
@@ -225,7 +231,9 @@
       "waterproof": "No informado (valor por defecto)",
       "peso": "No especificado (valor por defecto)",
       "garantia": "Garantía limitada de 1 año por defecto de fabricación (valor por defecto)"
-    }
+    },
+    "bestSeller": true,
+    "badge": "promo"
   },
   {
     "slug": "fetish-tronco-amor-inflable",

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -53,6 +53,7 @@ export type Product = {
   images?: number
   brand?: string
   badge?: 'nuevo' | 'top' | 'promo'
+  bestSeller?: boolean
   features?: string[]
   using?: string[]
   care?: string[]

--- a/public/textures/hero-texture.svg
+++ b/public/textures/hero-texture.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200" preserveAspectRatio="none">
+  <defs>
+    <filter id="noise" x="0" y="0">
+      <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="3" seed="11"/>
+      <feColorMatrix type="saturate" values="0"/>
+      <feComponentTransfer>
+        <feFuncA type="linear" slope="0.16"/>
+      </feComponentTransfer>
+    </filter>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <rect width="40" height="40" fill="rgba(255,255,255,0.02)" />
+      <path d="M0 0H40V40" fill="none" stroke="rgba(255,255,255,0.08)" stroke-width="1" />
+    </pattern>
+  </defs>
+  <rect width="200" height="200" fill="url(#grid)"/>
+  <rect width="200" height="200" filter="url(#noise)" opacity="0.45"/>
+</svg>


### PR DESCRIPTION
## Summary
- Rebuilt the home hero with stronger typography, motion copy, and a textured background that reinforces discretion messaging.
- Added trust badges, a draggable category carousel, and a best sellers section powered by reusable home components.
- Flagged top products in the catalog data to drive the new best sellers grid and surfaced badge styling in product cards.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0fd607bb0832194553b40338fd7a8