### PR TITLE
Add animated product card with quick view dialog

### DIFF
--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,6 +1,10 @@
 'use client'
 
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
+import Image from 'next/image'
+import { motion, type HTMLMotionProps } from 'framer-motion'
+import QuickViewDialog from '@/components/product/QuickViewDialog'
 import { useCategoryFilters } from '@/components/category/filters-context'
 import type { Product } from '@/lib/products'
 
@@ -10,15 +14,24 @@ const BADGE_LABELS: Record<NonNullable<Product['badge']>, string> = {
   promo: 'Promo'
 }
 
+const FALLBACK_IMAGE_SRC =
+  'data:image/svg+xml;charset=UTF-8,' +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240"><defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0%" stop-color="#f4f4f5"/><stop offset="100%" stop-color="#e4e4e7"/></linearGradient></defs><rect width="320" height="240" fill="url(#g)"/><text x="50%" y="50%" fill="#a1a1aa" font-family="sans-serif" font-size="20" font-weight="600" text-anchor="middle" dominant-baseline="middle">Producto</text></svg>`
+  )
+
 type ProductCardProps = {
-  p: Pick<Product, 'slug' | 'name' | 'price' | 'badge' | 'brand' | 'attributes'>
+  p: Product
   highlightBadge?: string
 }
 
 export default function ProductCard({ p, highlightBadge }: ProductCardProps) {
   const filtersContext = useCategoryFilters()
+  const [isQuickViewOpen, setIsQuickViewOpen] = useState(false)
+  const longPressTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const didTriggerQuickView = useRef(false)
 
-  const filterBadge = (() => {
+  const filterBadge = useMemo(() => {
     if (!filtersContext) return undefined
     if (filtersContext.isBrandSelected(p.brand)) {
       return p.brand ? `Marca: ${p.brand}` : undefined
@@ -28,30 +41,112 @@ export default function ProductCard({ p, highlightBadge }: ProductCardProps) {
       return material ? `Material: ${material}` : undefined
     }
     return undefined
-  })()
+  }, [filtersContext, p.attributes?.material, p.brand])
 
   const displayBadge = highlightBadge ?? filterBadge ?? (p.badge ? BADGE_LABELS[p.badge] : undefined)
+  const hasGallery = Boolean(p.images && p.images > 0 && p.nsfw)
+  const mainImageSrc = hasGallery ? `/nsfw-assets/${p.slug}/1.webp` : FALLBACK_IMAGE_SRC
+  const shouldPriorityLoad = Boolean(highlightBadge || p.badge === 'top')
+
+  useEffect(() => {
+    return () => {
+      if (longPressTimeout.current) {
+        clearTimeout(longPressTimeout.current)
+      }
+    }
+  }, [])
+
+  const cancelLongPress = () => {
+    if (longPressTimeout.current) {
+      clearTimeout(longPressTimeout.current)
+      longPressTimeout.current = null
+    }
+    didTriggerQuickView.current = false
+  }
+
+  const handleTouchStart = () => {
+    didTriggerQuickView.current = false
+    cancelLongPress()
+    longPressTimeout.current = setTimeout(() => {
+      didTriggerQuickView.current = true
+      setIsQuickViewOpen(true)
+    }, 500)
+  }
+
+  const handleTouchEnd: React.TouchEventHandler<HTMLAnchorElement> = (event) => {
+    if (longPressTimeout.current) {
+      clearTimeout(longPressTimeout.current)
+      longPressTimeout.current = null
+    }
+    if (didTriggerQuickView.current) {
+      event.preventDefault()
+      event.stopPropagation()
+      didTriggerQuickView.current = false
+    }
+  }
+
+  const handleTouchMove: React.TouchEventHandler<HTMLAnchorElement> = () => {
+    if (longPressTimeout.current) {
+      clearTimeout(longPressTimeout.current)
+      longPressTimeout.current = null
+    }
+    didTriggerQuickView.current = false
+  }
 
   return (
-    <Link
-      href={`/producto/${p.slug}`}
-      className="group block rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
-    >
-      <div className="relative aspect-[4/3] overflow-hidden rounded-xl bg-neutral-100">
-        <div
-          className="absolute inset-0 bg-gradient-to-br from-brand-primary/10 via-transparent to-brand-accent/20 opacity-0 transition group-hover:opacity-100"
-          aria-hidden
-        />
-        {displayBadge && (
-          <div className="absolute left-3 top-3 inline-flex items-center rounded-full bg-neutral-900/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white shadow-lg">
-            {displayBadge}
+    <div className="relative">
+      <Link href={`/producto/${p.slug}`} legacyBehavior passHref>
+        <motion.a
+          {...({
+            href: `/producto/${p.slug}`,
+            className: 'group block overflow-hidden rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm',
+            whileHover: { y: -4 },
+            whileTap: { scale: 0.98 },
+            transition: { type: 'spring', stiffness: 300, damping: 20, mass: 0.6 },
+            onTouchStart: handleTouchStart,
+            onTouchEnd: handleTouchEnd,
+            onTouchCancel: handleTouchMove,
+            onTouchMove: handleTouchMove
+          } as unknown as HTMLMotionProps<'a'>)}
+        >
+          <div className="relative aspect-[4/3] overflow-hidden rounded-xl bg-neutral-100">
+            <div
+              className="absolute inset-0 bg-gradient-to-br from-brand-primary/10 via-transparent to-brand-accent/20 opacity-0 transition group-hover:opacity-100"
+              aria-hidden
+            />
+            {displayBadge && (
+              <div className="absolute left-3 top-3 inline-flex items-center rounded-full bg-neutral-900/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white shadow-lg">
+                {displayBadge}
+              </div>
+            )}
+            <Image
+              src={mainImageSrc}
+              alt={p.name}
+              fill
+              priority={shouldPriorityLoad}
+              sizes="(min-width: 1024px) 280px, (min-width: 768px) 50vw, 90vw"
+              className={`h-full w-full object-cover transition duration-500 ${hasGallery ? 'group-hover:scale-105' : ''}`}
+            />
           </div>
-        )}
+          <div className="mt-3 space-y-1">
+            <div className="line-clamp-2 font-medium text-neutral-900">{p.name}</div>
+            <div className="font-semibold text-brand-primary">S/ {p.price.toFixed(2)}</div>
+            {p.brand && <div className="text-xs uppercase tracking-wide text-neutral-500">{p.brand}</div>}
+          </div>
+        </motion.a>
+      </Link>
+
+      <div className="pointer-events-none absolute inset-x-6 bottom-6 flex justify-center">
+        <button
+          type="button"
+          className="pointer-events-auto inline-flex items-center gap-2 rounded-full bg-neutral-900/90 px-4 py-2 text-sm font-medium text-white shadow-lg transition hover:bg-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+          onClick={() => setIsQuickViewOpen(true)}
+        >
+          Vista rápida
+        </button>
       </div>
-      <div className="mt-3 space-y-1">
-        <div className="line-clamp-2 font-medium text-neutral-900">{p.name}</div>
-        <div className="font-semibold text-brand-primary">S/ {p.price.toFixed(2)}</div>
-      </div>
-    </Link>
+
+      <QuickViewDialog product={p} open={isQuickViewOpen} onOpenChange={setIsQuickViewOpen} />
+    </div>
   )
 }

--- a/components/product/QuickViewDialog.tsx
+++ b/components/product/QuickViewDialog.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import { Fragment, useMemo } from 'react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { Dialog, Transition } from '@headlessui/react'
+import { X, MessageCircle, ShoppingBag } from 'lucide-react'
+import {
+  formatAttributeLabel,
+  formatAttributeValue,
+  getProductProperties,
+  type Product
+} from '@/lib/products'
+
+const FALLBACK_IMAGE_SRC =
+  'data:image/svg+xml;charset=UTF-8,' +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240"><defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0%" stop-color="#f4f4f5"/><stop offset="100%" stop-color="#e4e4e7"/></linearGradient></defs><rect width="320" height="240" fill="url(#g)"/><text x="50%" y="50%" fill="#a1a1aa" font-family="sans-serif" font-size="20" font-weight="600" text-anchor="middle" dominant-baseline="middle">Producto</text></svg>`
+  )
+
+const WHATSAPP_NUMBER = '51924281623'
+
+type QuickViewDialogProps = {
+  product: Product
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export default function QuickViewDialog({ product, open, onOpenChange }: QuickViewDialogProps) {
+  const galleryImages = useMemo(() => {
+    if (!product.images || product.images <= 0 || !product.nsfw) return []
+    return Array.from({ length: Math.min(product.images, 4) }, (_, index) => ({
+      src: `/nsfw-assets/${product.slug}/${index + 1}.webp`,
+      alt: `${product.name} — imagen ${index + 1}`
+    }))
+  }, [product])
+
+  const properties = useMemo(() => {
+    return getProductProperties(product.attributes, product.specs).slice(0, 4)
+  }, [product])
+
+  const features = product.features?.slice(0, 3) ?? []
+  const mainImage = galleryImages[0] ?? { src: FALLBACK_IMAGE_SRC, alt: product.name }
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onOpenChange}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-neutral-900/50" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center px-4 py-8">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-200"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-150"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="relative w-full max-w-4xl overflow-hidden rounded-3xl border border-neutral-200 bg-white shadow-2xl">
+                <button
+                  type="button"
+                  onClick={() => onOpenChange(false)}
+                  className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/80 text-neutral-500 shadow-md transition hover:bg-white hover:text-neutral-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+                  aria-label="Cerrar vista rápida"
+                >
+                  <X className="h-5 w-5" />
+                </button>
+
+                <div className="grid gap-6 p-6 md:grid-cols-[1.2fr,1fr] md:p-8">
+                  <div>
+                    <div className="relative aspect-square overflow-hidden rounded-2xl bg-neutral-100">
+                      <Image
+                        src={mainImage.src}
+                        alt={mainImage.alt}
+                        fill
+                        priority={open}
+                        sizes="(min-width: 1024px) 480px, 80vw"
+                        className={`object-cover ${galleryImages.length > 0 ? 'md:hover:scale-[1.02] md:transition-transform md:duration-500' : ''}`}
+                      />
+                    </div>
+                    {galleryImages.length > 1 && (
+                      <div className="mt-4 grid grid-cols-4 gap-2">
+                        {galleryImages.slice(1).map((image, index) => (
+                          <div key={image.src} className="relative aspect-square overflow-hidden rounded-xl border border-neutral-200 bg-neutral-100">
+                            <Image
+                              src={image.src}
+                              alt={image.alt}
+                              fill
+                              sizes="96px"
+                              priority={open && index < 2}
+                              className="object-cover"
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex flex-col justify-between gap-6">
+                    <div className="space-y-4">
+                      <Dialog.Title className="text-2xl font-semibold text-neutral-900">{product.name}</Dialog.Title>
+                      <Dialog.Description className="text-sm text-neutral-500">
+                        {product.brand && <span className="font-medium uppercase tracking-wide text-neutral-600">{product.brand}</span>}
+                        {product.brand && product.badge && <span className="mx-2 text-neutral-300">•</span>}
+                        {product.badge && <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold uppercase text-amber-700">{product.badge}</span>}
+                      </Dialog.Description>
+                      <div className="text-2xl font-bold text-brand-primary">S/ {product.price.toFixed(2)}</div>
+                      {features.length > 0 && (
+                        <ul className="space-y-2 rounded-2xl bg-neutral-50 p-4 text-sm text-neutral-700">
+                          {features.map((feature, index) => (
+                            <li key={index} className="flex items-start gap-2">
+                              <span className="mt-1 h-1.5 w-1.5 rounded-full bg-brand-primary" aria-hidden />
+                              <span>{feature}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                      {properties.length > 0 && (
+                        <dl className="grid gap-x-4 gap-y-2 text-sm text-neutral-600 sm:grid-cols-2">
+                          {properties.map(([key, value]) => (
+                            <div key={key} className="rounded-xl border border-neutral-200 bg-white px-3 py-2">
+                              <dt className="text-xs font-medium uppercase tracking-wide text-neutral-400">{formatAttributeLabel(key)}</dt>
+                              <dd className="mt-1 text-neutral-700">{formatAttributeValue(value)}</dd>
+                            </div>
+                          ))}
+                        </dl>
+                      )}
+                    </div>
+
+                    <div className="space-y-3">
+                      <Link
+                        href={`/checkout/success?sku=${product.sku}&value=${product.price}`}
+                        className="inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-brand-primary px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+                        onClick={() => onOpenChange(false)}
+                      >
+                        <ShoppingBag className="h-4 w-4" /> Comprar ahora
+                      </Link>
+                      <a
+                        href={`https://wa.me/${WHATSAPP_NUMBER}?text=Consulta%20${encodeURIComponent(product.sku)}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-neutral-200 px-4 py-3 text-sm font-semibold text-neutral-700 shadow-sm transition hover:border-brand-primary hover:text-brand-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+                      >
+                        <MessageCircle className="h-4 w-4" /> WhatsApp
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  )
+}


### PR DESCRIPTION
## Summary
- enhance ProductCard with framer-motion hover/tap animations, Next Image handling and long-press quick view trigger
- add reusable QuickViewDialog powered by Headless UI to show gallery, key attributes and CTAs
- integrate quick view button/CTA wiring so modal reuses normalized product data and stays accessible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d113573700832194799bbd0f2ee1e4