### PR TITLE
Refactor product image extension handling

### DIFF
--- a/components/NSFWGallery.tsx
+++ b/components/NSFWGallery.tsx
@@ -1,17 +1,24 @@
 'use client'
 import { useState } from 'react'
-import { resolveAssetFolder, SUPPORTED_IMAGE_EXTENSIONS } from '@/lib/products'
+import { DEFAULT_IMAGE_EXTENSIONS, resolveAssetFolder, type ImageExtension } from '@/lib/products'
 
-type Extension = (typeof SUPPORTED_IMAGE_EXTENSIONS)[number]
-
-function NSFWImage({ slug, index }: { slug: string; index: number }) {
+function NSFWImage({
+  slug,
+  index,
+  extensions
+}: {
+  slug: string
+  index: number
+  extensions: readonly ImageExtension[]
+}) {
   const [extIndex, setExtIndex] = useState(0)
   const [failed, setFailed] = useState(false)
-  const ext: Extension = SUPPORTED_IMAGE_EXTENSIONS[extIndex]
+  const hasExtensions = extensions.length > 0
+  const ext = hasExtensions ? extensions[Math.min(extIndex, extensions.length - 1)] : undefined
   const assetFolder = resolveAssetFolder({ nsfw: true })
-  const src = `/${assetFolder}/${slug}/${index}.${ext}`
+  const src = ext ? `/${assetFolder}/${slug}/${index}.${ext}` : undefined
 
-  if (failed) {
+  if (failed || !src) {
     return (
       <div className="w-full rounded-xl border border-dashed p-6 text-center text-xs text-neutral-500">
         Imagen {index} no disponible
@@ -26,7 +33,7 @@ function NSFWImage({ slug, index }: { slug: string; index: number }) {
       className="w-full rounded-xl border"
       loading="lazy"
       onError={() => {
-        if (extIndex < SUPPORTED_IMAGE_EXTENSIONS.length - 1) {
+        if (extIndex < extensions.length - 1) {
           setExtIndex(prev => prev + 1)
         } else {
           setFailed(true)
@@ -36,7 +43,15 @@ function NSFWImage({ slug, index }: { slug: string; index: number }) {
   )
 }
 
-export default function NSFWGallery({ slug, count }: { slug: string; count: number }) {
+export default function NSFWGallery({
+  slug,
+  count,
+  imageExtensions = DEFAULT_IMAGE_EXTENSIONS
+}: {
+  slug: string
+  count: number
+  imageExtensions?: readonly ImageExtension[]
+}) {
   const [show, setShow] = useState(false)
   if (!count) {
     return <div className="text-xs text-neutral-500">Imágenes disponibles al publicar</div>
@@ -52,7 +67,7 @@ export default function NSFWGallery({ slug, count }: { slug: string; count: numb
       ) : (
         <div className="space-y-3">
           {Array.from({ length: count }).map((_, i) => (
-            <NSFWImage key={i} slug={slug} index={i + 1} />
+            <NSFWImage key={i} slug={slug} index={i + 1} extensions={imageExtensions} />
           ))}
         </div>
       )}

--- a/data/products.json
+++ b/data/products.json
@@ -7,6 +7,9 @@
     "category": "bienestar",
     "assetFolder": "sfw-assets",
     "images": 8,
+    "imageSet": [
+      "jpg"
+    ],
     "attributes": {
       "material": "No especificado (valor por defecto)",
       "longitud": "No especificada (valor por defecto)",
@@ -27,6 +30,9 @@
     "category": "bienestar",
     "assetFolder": "sfw-assets",
     "images": 8,
+    "imageSet": [
+      "jpg"
+    ],
     "attributes": {
       "material": "No especificado (valor por defecto)",
       "longitud": "No especificada (valor por defecto)",
@@ -45,6 +51,9 @@
     "category": "bienestar",
     "assetFolder": "sfw-assets",
     "images": 5,
+    "imageSet": [
+      "jpg"
+    ],
     "attributes": {
       "material": "No especificado (valor por defecto)",
       "longitud": "No especificada (valor por defecto)",
@@ -63,6 +72,9 @@
     "category": "bienestar",
     "assetFolder": "sfw-assets",
     "images": 1,
+    "imageSet": [
+      "jpg"
+    ],
     "attributes": {
       "material": "No especificado (valor por defecto)",
       "longitud": "No especificada (valor por defecto)",


### PR DESCRIPTION
## Summary
- add default image extension handling with optional per-product overrides
- refactor product surfaces to consume configured image extension lists without filesystem checks
- annotate catalog data for products that require jpg-only image sets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1db10dd3083219faa456439ed6a05