### PR TITLE
Add runtime and static params to product page

### DIFF
--- a/app/producto/[slug]/page.tsx
+++ b/app/producto/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import {
   DEFAULT_IMAGE_EXTENSIONS,
+  allProducts,
   bySlug,
   formatAttributeLabel,
   formatAttributeValue,
@@ -15,6 +16,12 @@ import Breadcrumbs from '@/components/ui/Breadcrumbs'
 import TrustBadges from '@/components/ui/TrustBadges'
 import SpecsTable from '@/components/ui/SpecsTable'
 import Sections from '@/components/ui/Sections'
+
+export const runtime = 'nodejs'
+
+export function generateStaticParams() {
+  return allProducts().map(product => ({ slug: product.slug }))
+}
 
 export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
   const p = bySlug(params.slug)


### PR DESCRIPTION
## Summary
- declare the Node.js runtime for the dynamic product route
- generate static params from all available products to support static rendering

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d1e1a4b3cc8321b038b3677d5be23b