### PR TITLE
feat: refresh home hero and merchandising

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import Link from 'next/link'
 import { PackageCheck, ShieldCheck, LockKeyhole } from 'lucide-react'
 import Hero from '@/components/Hero'
@@ -7,7 +6,11 @@ import CategoryCarousel from '@/components/home/CategoryCarousel'
 import BestSellers from '@/components/home/BestSellers'
 import TrustBadgesStrip from '@/components/home/TrustBadgesStrip'
 import HeroCarousel from '@/components/home/HeroCarousel'
+import FeaturedProducts from '@/components/home/FeaturedProducts'
+import InspirationalBanner from '@/components/home/InspirationalBanner'
 import categoriesData from '@/data/categories.json'
+
+type AvailableProduct = ReturnType<typeof allProducts>[number]
 
 const featuredCategories = ['bienestar', 'lenceria', 'kits'] as const
 
@@ -38,6 +41,14 @@ const TRUST_BADGES = [
   }
 ]
 
+const PREMIUM_PRODUCT_SLUGS = [
+  'ultimate-fantasy-dolls-mandy-copia',
+  'bathmate-hydromax7-x30-britanico-original',
+  'xtreme-x30-britanico-original'
+] as const
+
+const HIGHLIGHTED_CATEGORY_LIMIT = 8
+
 export default function Page() {
   const products = allProducts()
   const bestSellers = getBestSellers()
@@ -62,28 +73,56 @@ export default function Page() {
   const featured = availableCategories.filter(category =>
     (featuredCategories as readonly string[]).includes(category.slug)
   )
-  const otherCategories = availableCategories.filter(
-    category => !featured.some(featuredCategory => featuredCategory.slug === category.slug)
-  )
-  const carouselCategories = featured.length > 0 ? featured : availableCategories
+  const carouselSource = featured.length > 0 ? featured : availableCategories
+  const highlightedCategories = carouselSource.slice(0, HIGHLIGHTED_CATEGORY_LIMIT)
+  const hasMoreCategories = availableCategories.length > highlightedCategories.length
+
+  const premiumProducts = PREMIUM_PRODUCT_SLUGS.map(slug =>
+    products.find(product => product.slug === slug)
+  ).filter((product): product is AvailableProduct => Boolean(product))
 
   return (
     <>
       <Hero />
-      <div className="mt-8">
-        <HeroCarousel />
+      <div className="mt-8 lg:hidden">
+        <HeroCarousel className="bg-white/70" />
       </div>
-      <div className="mt-6 space-y-6">
+      <div className="mt-10 space-y-12">
         <TrustBadgesStrip badges={TRUST_BADGES} />
-        <CategoryCarousel
-          title="Explora por categoría"
-          subtitle="Mobile-first con desliz lateral — arrastra para descubrir más."
-          headingId="explora-por-categoria"
-          categories={carouselCategories}
+        <section className="space-y-6" id="catalogo">
+          <CategoryCarousel
+            title="Explora por categoría"
+            subtitle="Mobile-first con desliz lateral — arrastra para descubrir más."
+            headingId="explora-por-categoria"
+            categories={highlightedCategories}
+          />
+          {hasMoreCategories && (
+            <div className="flex justify-end">
+              <Link
+                href="/categorias"
+                className="inline-flex items-center rounded-full border border-neutral-200 bg-white px-5 py-2 text-sm font-semibold text-neutral-700 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900"
+              >
+                Ver más categorías
+              </Link>
+            </div>
+          )}
+        </section>
+        <FeaturedProducts products={premiumProducts} headingId="productos-destacados" />
+        <InspirationalBanner
+          eyebrow="Editorial 69"
+          title="Sensualidad consciente"
+          description="Eleva tus rituales íntimos con materiales hipoalergénicos, cosmética vegana y guías diseñadas por terapeutas certificados."
+          image="/hero/juguetes-anales-premium.svg"
+          imageAlt="Ilustración de juguetes premium en tonos metálicos"
+          ctaHref="/colecciones/wellness"
+          ctaLabel="Explorar rituales"
         />
-      </div>
-      <div className="mt-12 space-y-12">
-        <BestSellers products={bestSellers} headingId="mas-vendidos" />
+        <BestSellers
+          products={bestSellers}
+          headingId="mas-vendidos"
+          layout="carousel"
+          maxVisible={6}
+        />
         {newArrivals.length > 0 && (
           <BestSellers
             products={newArrivals}
@@ -94,8 +133,20 @@ export default function Page() {
             ctaLabel="Ver novedades"
             highlightBadges={newArrivalHighlightBadges}
             showBestSellerHighlight={false}
+            layout="carousel"
+            maxVisible={6}
           />
         )}
+        <InspirationalBanner
+          align="right"
+          eyebrow="Historias reales"
+          title="Parejas que experimentan"
+          description="Descubre testimonios curados y sesiones guiadas para sincronizar ritmos, explorar comunicación íntima y potenciar el deseo mutuo."
+          image="/hero/parejas-curiosas-neon.svg"
+          imageAlt="Ilustración futurista de pareja conectada"
+          ctaHref="/blog/parejas"
+          ctaLabel="Leer historias"
+        />
         {offers.length > 0 && (
           <BestSellers
             products={offers}
@@ -106,40 +157,9 @@ export default function Page() {
             ctaLabel="Ver ofertas"
             highlightBadges={offerHighlightBadges}
             showBestSellerHighlight={false}
+            layout="carousel"
+            maxVisible={6}
           />
-        )}
-        {otherCategories.length > 0 && (
-          <section className="space-y-4">
-            <h2 id="buscas-algo-mas-especifico" className="text-xl font-semibold text-neutral-900">
-              ¿Buscas algo más específico?
-            </h2>
-            <p className="text-sm text-neutral-600">
-              Recorre las categorías sensibles y temáticas creadas para diferentes niveles de experiencia.
-            </p>
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                {otherCategories.map(category => (
-                  <Link
-                    key={category.slug}
-                    href={`/categoria/${category.slug}`}
-                    className="flex flex-col items-center rounded-2xl border border-neutral-200 bg-white/90 p-4 text-center shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
-                  >
-                    <div className="relative mb-3 h-20 w-20 overflow-hidden rounded-full border border-neutral-200 bg-neutral-50">
-                      <Image
-                        src={category.image ?? CATEGORY_FALLBACK_IMAGE}
-                        alt={`${category.label} — miniatura de categoría`}
-                        fill
-                        sizes="80px"
-                        className="object-cover"
-                      />
-                    </div>
-                    <div className="text-base font-semibold text-neutral-900">{category.label}</div>
-                    <div className="mt-2 text-sm text-neutral-600">
-                      {category.isSensitive ? 'Contenido sensible (18+)' : 'Explorar con seguridad'}
-                    </div>
-                  </Link>
-                ))}
-              </div>
-            </section>
         )}
       </div>
     </>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,66 +1,263 @@
 'use client'
 
+import { useEffect, useMemo, useState } from 'react'
+import Image from 'next/image'
 import Link from 'next/link'
-import { motion, type Variants } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 
-const headlineVariants: Variants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: { opacity: 1, y: 0 }
+const AUTO_PLAY_DELAY = 9000
+
+const baseButtonClasses =
+  'inline-flex items-center justify-center rounded-full px-6 py-3 text-base font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white'
+
+const primaryButtonClasses = `${baseButtonClasses} bg-white text-neutral-900 shadow-xl shadow-black/30 hover:bg-neutral-200`
+const secondaryButtonClasses = `${baseButtonClasses} border border-white/40 bg-white/10 text-white backdrop-blur hover:bg-white/20`
+
+type SlideMedia =
+  | { type: 'image'; src: string; alt: string }
+  | { type: 'video'; src: string; poster?: string; alt?: string }
+
+type Slide = {
+  id: string
+  tag: string
+  title: string
+  description: string
+  media: SlideMedia
 }
 
-const copyVariants: Variants = {
-  hidden: { opacity: 0, y: 12 },
-  visible: { opacity: 1, y: 0 }
-}
+const slides: Slide[] = [
+  {
+    id: 'neon-seduction',
+    tag: 'Noches eléctricas',
+    title: 'Luces bajas, fantasías altas',
+    description:
+      'Escenarios inmersivos con lencería glow-in-the-dark, texturas líquidas y accesorios que responden a cada caricia.',
+    media: {
+      type: 'image',
+      src: '/hero/noches-electricas.svg',
+      alt: 'Pareja en un ambiente nocturno con luces neón'
+    }
+  },
+  {
+    id: 'rituales-high-tech',
+    tag: 'Autocuidado vibrante',
+    title: 'Rituales sensoriales high-tech',
+    description:
+      'Dispositivos inteligentes sincronizados con respiraciones, aceites multisensoriales y playlists binaurales a un toque.',
+    media: {
+      type: 'video',
+      src: 'https://cdn.coverr.co/videos/coverr-passing-lights-on-a-night-highway-4105/1080p.mp4',
+      poster: '/hero/autocuidado-vibrante-neon.svg',
+      alt: 'Luces desenfocadas en movimiento evocando una ciudad nocturna'
+    }
+  },
+  {
+    id: 'parejas-sincronizadas',
+    tag: 'Parejas curiosas',
+    title: 'Placer sincronizado sin tabúes',
+    description:
+      'Juguetes conectados, aromas envolventes y coaching íntimo para explorar en conjunto a tu ritmo.',
+    media: {
+      type: 'image',
+      src: '/hero/parejas-curiosas-neon.svg',
+      alt: 'Ilustración de dos siluetas tocándose en ambiente futurista'
+    }
+  }
+]
 
 export default function Hero() {
+  const preparedSlides = useMemo(() => slides, [])
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [isPaused, setIsPaused] = useState(false)
+
+  useEffect(() => {
+    if (isPaused || preparedSlides.length <= 1) return
+
+    const timer = window.setInterval(() => {
+      setActiveIndex(prev => (prev + 1) % preparedSlides.length)
+    }, AUTO_PLAY_DELAY)
+
+    return () => window.clearInterval(timer)
+  }, [isPaused, preparedSlides.length])
+
+  const goTo = (index: number) => {
+    setActiveIndex(((index % preparedSlides.length) + preparedSlides.length) % preparedSlides.length)
+  }
+
+  const handlePrevious = () => {
+    goTo(activeIndex - 1)
+  }
+
+  const handleNext = () => {
+    goTo(activeIndex + 1)
+  }
+
+  const activeSlide = preparedSlides[activeIndex]
+
   return (
-    <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-[#7f00ff]/30 via-[#e100ff]/20 to-[#ff6f91]/40 p-6 sm:p-10 md:p-14">
+    <section
+      aria-roledescription="carrusel"
+      aria-label="Experiencias destacadas"
+      className="relative isolate flex min-h-[80vh] flex-col overflow-hidden rounded-[2.5rem] border border-white/10 bg-neutral-950 text-white shadow-[0_40px_120px_-40px_rgba(126,34,206,0.45)]"
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+      onFocusCapture={() => setIsPaused(true)}
+      onBlurCapture={() => setIsPaused(false)}
+    >
       <div className="absolute inset-0">
-        <div className="absolute inset-0 bg-[url('/textures/hero-texture.svg')] bg-cover opacity-50 mix-blend-overlay" aria-hidden />
-        <div className="absolute inset-0 bg-gradient-to-br from-[#7f00ff]/25 via-transparent to-[#ff6f91]/35" aria-hidden />
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.div
+            key={activeSlide.id}
+            className="absolute inset-0"
+            initial={{ opacity: 0, scale: 1.05 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.98 }}
+            transition={{ duration: 0.8, ease: 'easeOut' }}
+            aria-hidden
+          >
+            {activeSlide.media.type === 'image' ? (
+              <Image
+                src={activeSlide.media.src}
+                alt={activeSlide.media.alt}
+                fill
+                priority
+                sizes="100vw"
+                className="object-cover object-center"
+              />
+            ) : (
+              <video
+                className="h-full w-full object-cover"
+                autoPlay
+                muted
+                loop
+                playsInline
+                poster={activeSlide.media.poster}
+              >
+                <source src={activeSlide.media.src} type="video/mp4" />
+              </video>
+            )}
+            <div className="absolute inset-0 bg-gradient-to-br from-neutral-950/85 via-neutral-950/45 to-transparent" />
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(126,34,206,0.35),_transparent_60%)]" />
+          </motion.div>
+        </AnimatePresence>
       </div>
 
-      <div className="relative z-10 flex flex-col gap-10 md:flex-row md:items-center md:justify-between">
-        <div className="max-w-2xl">
-          <motion.div
-            initial="hidden"
-            animate="visible"
-            variants={headlineVariants}
-            transition={{ duration: 0.6, ease: 'easeOut' }}
-          >
-            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-brand-primary/90">Confianza real, placer privado</p>
-            <h1 className="mt-4 text-3xl font-semibold leading-tight text-neutral-900 sm:text-4xl md:text-[2.9rem] md:leading-[1.05]">
-              Tu intimidad es prioridad: experiencias premium con envíos ultra discretos
-            </h1>
-          </motion.div>
+      <div className="relative z-10 flex flex-1 flex-col justify-between px-6 py-14 sm:px-10 lg:px-16">
+        <div className="flex flex-wrap items-center justify-between gap-4 text-xs font-semibold uppercase tracking-[0.35em] text-white/70">
+          <span>{activeSlide.tag}</span>
+          <span>
+            {activeIndex + 1}/{preparedSlides.length}
+          </span>
         </div>
 
-        <div className="max-w-md space-y-6 text-neutral-700">
-          <motion.div
-            initial="hidden"
-            animate="visible"
-            variants={copyVariants}
-            transition={{ delay: 0.2, duration: 0.6, ease: 'easeOut' }}
-          >
-            <div className="space-y-6">
-              <p className="text-base leading-relaxed md:text-lg">
-                Compra desde casa con asesoría segura y pagos protegidos. Cada pedido viaja en embalaje sin marcas y con seguimiento privado para que solo tú sepas lo que llega.
-              </p>
-              <div className="flex flex-wrap gap-3 text-sm">
-                <span className="rounded-full bg-white/70 px-4 py-2 font-medium text-neutral-900 shadow-sm">Soporte 24/7 confidencial</span>
-                <span className="rounded-full bg-white/50 px-4 py-2 font-medium text-neutral-900 shadow-sm">Facturación anónima</span>
-              </div>
-              <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-                <Link
-                  href="#catalogo"
-                  className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-base font-semibold text-white shadow-lg shadow-neutral-900/30 transition hover:bg-neutral-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900"
+        <div className="mt-10 grid flex-1 items-center gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.6fr)]">
+          <div className="space-y-6">
+            <motion.h1
+              key={activeSlide.title}
+              initial={{ opacity: 0, y: 30 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.7, ease: 'easeOut' }}
+              className="text-4xl font-semibold leading-tight sm:text-5xl lg:text-[3.6rem] lg:leading-[1.05]"
+            >
+              {activeSlide.title}
+            </motion.h1>
+            <motion.p
+              key={activeSlide.description}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1, duration: 0.6, ease: 'easeOut' }}
+              className="max-w-xl text-base leading-relaxed text-white/80 sm:text-lg"
+            >
+              {activeSlide.description}
+            </motion.p>
+            <motion.div
+              className="flex flex-wrap gap-4"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2, duration: 0.6, ease: 'easeOut' }}
+            >
+              <Link href="#catalogo" className={primaryButtonClasses}>
+                Explorar catálogo
+              </Link>
+              <Link href="/experiencias" className={secondaryButtonClasses}>
+                Descubre el placer
+              </Link>
+            </motion.div>
+          </div>
+
+          <div className="hidden h-full min-h-[320px] lg:block">
+            <div className="relative h-full w-full overflow-hidden rounded-[2rem] border border-white/20 bg-white/5">
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.div
+                  key={`preview-${activeSlide.id}`}
+                  className="absolute inset-0"
+                  initial={{ opacity: 0, scale: 1.04 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.98 }}
+                  transition={{ duration: 0.6, ease: 'easeOut' }}
+                  aria-hidden
                 >
-                  Explorar catálogo seguro
-                </Link>
-              </motion.div>
+                  {activeSlide.media.type === 'image' ? (
+                    <Image
+                      src={activeSlide.media.src}
+                      alt={activeSlide.media.alt}
+                      fill
+                      sizes="40vw"
+                      className="object-cover object-center"
+                    />
+                  ) : (
+                    <video
+                      className="h-full w-full object-cover"
+                      autoPlay
+                      muted
+                      loop
+                      playsInline
+                      poster={activeSlide.media.poster}
+                    >
+                      <source src={activeSlide.media.src} type="video/mp4" />
+                    </video>
+                  )}
+                  <div className="absolute inset-0 bg-gradient-to-br from-brand-primary/30 via-transparent to-brand-accent/30 mix-blend-screen" />
+                </motion.div>
+              </AnimatePresence>
             </div>
-          </motion.div>
+          </div>
+        </div>
+
+        <div className="mt-12 flex items-center justify-between gap-4 text-xs text-white/60">
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handlePrevious}
+              aria-label="Ver historia anterior"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-white/30 bg-white/10 backdrop-blur transition hover:bg-white/25 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            >
+              ‹
+            </button>
+            <button
+              type="button"
+              onClick={handleNext}
+              aria-label="Ver siguiente historia"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-white/30 bg-white/10 backdrop-blur transition hover:bg-white/25 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            >
+              ›
+            </button>
+          </div>
+          <div className="flex flex-1 justify-end gap-2">
+            {preparedSlides.map((slide, index) => {
+              const isActive = index === activeIndex
+              return (
+                <button
+                  key={slide.id}
+                  type="button"
+                  onClick={() => goTo(index)}
+                  aria-label={`Ir a la experiencia ${slide.title}`}
+                  aria-current={isActive}
+                  className={`h-2 rounded-full transition-all ${isActive ? 'w-12 bg-white' : 'w-6 bg-white/40 hover:bg-white/70'}`}
+                />
+              )
+            })}
+          </div>
         </div>
       </div>
     </section>

--- a/components/home/BestSellers.tsx
+++ b/components/home/BestSellers.tsx
@@ -1,7 +1,8 @@
 'use client'
 
+import { useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
-import { ArrowRight } from 'lucide-react'
+import { ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react'
 import { motion, type Variants } from 'framer-motion'
 import type { Product } from '@/lib/products'
 import ProductCard from '@/components/ProductCard'
@@ -15,6 +16,8 @@ type BestSellersProps = {
   ctaLabel?: string
   highlightBadges?: Record<string, string>
   showBestSellerHighlight?: boolean
+  layout?: 'grid' | 'carousel'
+  maxVisible?: number
 }
 
 const sectionVariants: Variants = {
@@ -30,9 +33,52 @@ export default function BestSellers({
   ctaHref = '/categoria/bienestar',
   ctaLabel = 'Descubrir más',
   highlightBadges,
-  showBestSellerHighlight = true
+  showBestSellerHighlight = true,
+  layout = 'grid',
+  maxVisible
 }: BestSellersProps) {
-  if (!products.length) return null
+  const displayedProducts = useMemo(
+    () => (maxVisible ? products.slice(0, maxVisible) : products),
+    [maxVisible, products]
+  )
+
+  const railRef = useRef<HTMLDivElement>(null)
+  const [canScrollLeft, setCanScrollLeft] = useState(false)
+  const [canScrollRight, setCanScrollRight] = useState(false)
+
+  const updateScrollButtons = () => {
+    const rail = railRef.current
+    if (!rail) return
+    const { scrollLeft, scrollWidth, clientWidth } = rail
+    setCanScrollLeft(scrollLeft > 8)
+    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 8)
+  }
+
+  useEffect(() => {
+    if (layout !== 'carousel') return
+
+    updateScrollButtons()
+    const rail = railRef.current
+    if (!rail) return
+
+    const handleScroll = () => updateScrollButtons()
+    rail.addEventListener('scroll', handleScroll)
+    window.addEventListener('resize', handleScroll)
+
+    return () => {
+      rail.removeEventListener('scroll', handleScroll)
+      window.removeEventListener('resize', handleScroll)
+    }
+  }, [layout, displayedProducts.length])
+
+  if (!displayedProducts.length) return null
+
+  const scrollBy = (direction: 'left' | 'right') => {
+    const rail = railRef.current
+    if (!rail) return
+    const amount = direction === 'left' ? -rail.clientWidth + 120 : rail.clientWidth - 120
+    rail.scrollBy({ left: amount, behavior: 'smooth' })
+  }
 
   return (
     <section className="space-y-6" aria-labelledby={headingId ?? undefined}>
@@ -62,24 +108,86 @@ export default function BestSellers({
           )}
         </div>
       </motion.div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {products.map((product, index) => (
-          <motion.div
-            key={product.slug}
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.2 }}
-            transition={{ delay: index * 0.05, duration: 0.4, ease: 'easeOut' }}
+      {layout === 'carousel' ? (
+        <div className="relative">
+          <div
+            className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-white via-white/60 to-transparent"
+            aria-hidden
+          />
+          <div
+            className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-white via-white/60 to-transparent"
+            aria-hidden
+          />
+          <div
+            ref={railRef}
+            className="-mx-4 flex gap-4 overflow-x-auto scroll-smooth px-4 pb-4 snap-x snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            aria-live="polite"
           >
-            <ProductCard
-              p={product}
-              highlightBadge={
-                highlightBadges?.[product.slug] ?? (showBestSellerHighlight && product.bestSeller ? 'Best Seller' : undefined)
-              }
-            />
-          </motion.div>
-        ))}
-      </div>
+            {displayedProducts.map((product, index) => (
+              <motion.div
+                key={product.slug}
+                className="min-w-[240px] max-w-[320px] basis-[80%] snap-start flex-shrink-0 sm:basis-[45%] lg:basis-[28%] xl:basis-[22%]"
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true, amount: 0.2 }}
+                transition={{ delay: index * 0.05, duration: 0.4, ease: 'easeOut' }}
+              >
+                <ProductCard
+                  p={product}
+                  highlightBadge={
+                    highlightBadges?.[product.slug] ??
+                    (showBestSellerHighlight && product.bestSeller ? 'Best Seller' : undefined)
+                  }
+                />
+              </motion.div>
+            ))}
+          </div>
+          <div className="pointer-events-none absolute inset-x-0 top-1/2 flex -translate-y-1/2 justify-between px-1">
+            <button
+              type="button"
+              onClick={() => scrollBy('left')}
+              disabled={!canScrollLeft}
+              aria-label="Ver productos anteriores"
+              className={`pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full border border-neutral-200 bg-white/90 text-neutral-900 shadow-lg transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900 ${
+                canScrollLeft ? 'hover:bg-white' : 'cursor-not-allowed opacity-50'
+              }`}
+            >
+              <ChevronLeft className="h-4 w-4" aria-hidden />
+            </button>
+            <button
+              type="button"
+              onClick={() => scrollBy('right')}
+              disabled={!canScrollRight}
+              aria-label="Ver productos siguientes"
+              className={`pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full border border-neutral-200 bg-white/90 text-neutral-900 shadow-lg transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900 ${
+                canScrollRight ? 'hover:bg-white' : 'cursor-not-allowed opacity-50'
+              }`}
+            >
+              <ChevronRight className="h-4 w-4" aria-hidden />
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {displayedProducts.map((product, index) => (
+            <motion.div
+              key={product.slug}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.2 }}
+              transition={{ delay: index * 0.05, duration: 0.4, ease: 'easeOut' }}
+            >
+              <ProductCard
+                p={product}
+                highlightBadge={
+                  highlightBadges?.[product.slug] ??
+                  (showBestSellerHighlight && product.bestSeller ? 'Best Seller' : undefined)
+                }
+              />
+            </motion.div>
+          ))}
+        </div>
+      )}
     </section>
   )
 }

--- a/components/home/FeaturedProducts.tsx
+++ b/components/home/FeaturedProducts.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+import type { Product } from '@/lib/products'
+
+const FALLBACK_IMAGE_SRC =
+  'data:image/svg+xml;charset=UTF-8,' +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 320"><defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0%" stop-color="#18181b"/><stop offset="100%" stop-color="#3f3f46"/></linearGradient></defs><rect width="480" height="320" fill="url(#g)"/><text x="50%" y="50%" fill="#d4d4d8" font-family="sans-serif" font-size="24" font-weight="600" text-anchor="middle" dominant-baseline="middle">Destacado premium</text></svg>`
+  )
+
+type FeaturedProductsProps = {
+  products: Product[]
+  headingId?: string
+}
+
+const containerVariants = {
+  hidden: { opacity: 0, y: 32 },
+  visible: { opacity: 1, y: 0 }
+}
+
+export default function FeaturedProducts({ products, headingId }: FeaturedProductsProps) {
+  if (products.length === 0) return null
+
+  const columnsClass = products.length === 1 ? 'lg:grid-cols-1' : products.length === 2 ? 'lg:grid-cols-2' : 'lg:grid-cols-3'
+
+  return (
+    <section className="space-y-8" aria-labelledby={headingId}>
+      <div className="space-y-2">
+        <h2 id={headingId} className="text-3xl font-semibold text-neutral-900">
+          Productos destacados
+        </h2>
+        <p className="max-w-2xl text-sm text-neutral-600">
+          Piezas de lujo seleccionadas para experiencias intensas, con materiales premium, embalaje discreto y soporte experto.
+        </p>
+      </div>
+
+      <motion.div
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once: true, amount: 0.3 }}
+        variants={containerVariants}
+        transition={{ duration: 0.6, ease: 'easeOut' }}
+        className={`grid grid-cols-1 gap-6 ${columnsClass}`}
+      >
+        {products.map((product, index) => {
+          const filename = product.imageFilenames[0] ?? null
+          const imageBasename = filename ? filename.replace(/\..+$/, '') : null
+          const imageSrc = imageBasename ? `/products/${product.slug}/${imageBasename}.webp` : FALLBACK_IMAGE_SRC
+          const price = (product.salePrice ?? product.regularPrice).toFixed(2)
+
+          return (
+            <motion.article
+              key={product.slug}
+              className="group relative overflow-hidden rounded-[2rem] border border-neutral-200 bg-gradient-to-br from-white via-white to-neutral-50 shadow-xl"
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true, amount: 0.2 }}
+              transition={{ delay: index * 0.05, duration: 0.45, ease: 'easeOut' }}
+            >
+              <div className="relative h-72 overflow-hidden">
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(126,34,206,0.15),_transparent_60%)] opacity-0 transition group-hover:opacity-100" aria-hidden />
+                <Image
+                  src={imageSrc}
+                  alt={product.name}
+                  fill
+                  sizes="(min-width: 1024px) 28vw, 100vw"
+                  className="object-contain object-center"
+                />
+              </div>
+              <div className="relative space-y-4 p-8">
+                <div className="space-y-2">
+                  <span className="inline-flex items-center rounded-full bg-neutral-900/90 px-4 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-white">Premium</span>
+                  <h3 className="text-2xl font-semibold text-neutral-900">{product.name}</h3>
+                  {product.shortDescription && (
+                    <p className="text-sm leading-relaxed text-neutral-600">{product.shortDescription}</p>
+                  )}
+                </div>
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <span className="text-lg font-semibold text-brand-primary">S/ {price}</span>
+                  <Link
+                    href={`/producto/${product.slug}`}
+                    className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-neutral-900/40 transition hover:bg-neutral-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900"
+                  >
+                    Comprar ahora
+                  </Link>
+                </div>
+              </div>
+              <div className="pointer-events-none absolute inset-0 border border-white/20 mix-blend-overlay" aria-hidden />
+            </motion.article>
+          )
+        })}
+      </motion.div>
+    </section>
+  )
+}

--- a/components/home/InspirationalBanner.tsx
+++ b/components/home/InspirationalBanner.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+
+type InspirationalBannerProps = {
+  title: string
+  description: string
+  image: string
+  imageAlt: string
+  eyebrow?: string
+  align?: 'left' | 'right'
+  ctaHref?: string
+  ctaLabel?: string
+}
+
+export default function InspirationalBanner({
+  title,
+  description,
+  image,
+  imageAlt,
+  eyebrow,
+  align = 'left',
+  ctaHref,
+  ctaLabel
+}: InspirationalBannerProps) {
+  const imageElement = (
+    <div className="relative h-64 overflow-hidden rounded-[2.25rem] lg:h-full">
+      <Image src={image} alt={imageAlt} fill className="object-cover" sizes="(min-width: 1024px) 50vw, 100vw" />
+      <div
+        className="absolute inset-0 bg-gradient-to-br from-brand-primary/20 via-transparent to-brand-accent/30 mix-blend-multiply"
+        aria-hidden
+      />
+    </div>
+  )
+
+  const contentElement = (
+    <div className="flex flex-col justify-center gap-6 px-8 py-10">
+      {eyebrow && <span className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-primary">{eyebrow}</span>}
+      <div className="space-y-4">
+        <h3 className="text-3xl font-semibold text-neutral-900">{title}</h3>
+        <p className="text-base leading-relaxed text-neutral-600">{description}</p>
+      </div>
+      {ctaHref && ctaLabel && (
+        <div>
+          <Link
+            href={ctaHref}
+            className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-neutral-900/30 transition hover:bg-neutral-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900"
+          >
+            {ctaLabel}
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 30 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+      transition={{ duration: 0.6, ease: 'easeOut' }}
+      className="relative overflow-hidden rounded-[2.25rem] border border-neutral-200 bg-white shadow-[0_30px_80px_-40px_rgba(126,34,206,0.35)]"
+    >
+      <div className="grid gap-8 lg:grid-cols-2">
+        {align === 'left' ? (
+          <>
+            {imageElement}
+            {contentElement}
+          </>
+        ) : (
+          <>
+            {contentElement}
+            {imageElement}
+          </>
+        )}
+      </div>
+    </motion.section>
+  )
+}


### PR DESCRIPTION
## Summary
- replace the home hero with a full-screen cinematic carousel with gradient overlays, video support, and CTA buttons
- add premium merchandising components (featured products, inspirational banners) and reorganise the homepage flow with limited categories and mobile hero highlights
- upgrade product highlights into horizontal carousels for best sellers, new arrivals and offers with smooth navigation controls

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d330e2f574832184cd7246e794f246