### PR TITLE
Add Link import to homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { PackageCheck, ShieldCheck, LockKeyhole } from 'lucide-react'
+import Link from 'next/link'
 import Hero from '@/components/Hero'
 import { allProducts, getBestSellers, getNewArrivals, getOffers } from '@/lib/products'
 import CategoryCarousel, { CategoryCard } from '@/components/home/CategoryCarousel'


### PR DESCRIPTION
## Summary
- import the Next.js Link component in the homepage to satisfy existing usage

## Testing
- `CI=1 npm run build` *(fails: Type error in components/Header.tsx: className missing in motion.div props)*

------
https://chatgpt.com/codex/tasks/task_e_68d33638a2688321a9a7b34fa4e442a9