### PR TITLE
feat: apply neon night theme to landing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,7 +2,17 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { color-scheme: light; }
+:root {
+  color-scheme: dark;
+  --color-background: #05000f;
+  --color-foreground: #f7f2ff;
+  --color-muted-foreground: #cbbdf5;
+  --color-subtle-foreground: #a99eda;
+  --color-surface: rgba(26, 6, 43, 0.85);
+  --color-surface-strong: #170629;
+  --color-border: rgba(219, 196, 255, 0.25);
+  --color-border-strong: rgba(236, 208, 255, 0.45);
+}
 
 @font-face {
   font-family: 'Inter';
@@ -16,5 +26,13 @@
 @layer base {
   html {
     font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+  body {
+    background-color: var(--color-background);
+    color: var(--color-foreground);
+  }
+  ::selection {
+    background-color: rgba(236, 72, 153, 0.65);
+    color: #fff;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -70,7 +70,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <link rel="preconnect" href="https://plausible.io" />
         )}
       </head>
-      <body className="min-h-screen bg-white text-neutral-900 antialiased">
+      <body className="min-h-screen bg-night-radial text-night-foreground antialiased">
         <Suspense fallback={null}>
           <Tracker />
         </Suspense>

--- a/app/legal/devoluciones/page.tsx
+++ b/app/legal/devoluciones/page.tsx
@@ -1,9 +1,9 @@
 ﻿export default function Devoluciones(){
   return (
-    <main className="max-w-3xl mx-auto py-10">
-      <h1 className="text-3xl font-semibold">Cambios y Devoluciones</h1>
-      <p className="mt-3 text-neutral-700">Por higiene, no se aceptan devoluciones de productos íntimos con empaque abierto. Fallas de fábrica: contacto dentro de 7 días para evaluación y solución.</p>
-      <p className="mt-6 text-sm text-neutral-500">Versión piloto.</p>
+    <main className="mx-auto max-w-3xl py-10 text-night-foreground">
+      <h1 className="text-3xl font-semibold text-white">Cambios y Devoluciones</h1>
+      <p className="mt-3 text-night-muted">Por higiene, no se aceptan devoluciones de productos íntimos con empaque abierto. Fallas de fábrica: contacto dentro de 7 días para evaluación y solución.</p>
+      <p className="mt-6 text-sm text-night-subtle">Versión piloto.</p>
     </main>
   )
 }

--- a/app/legal/privacidad/page.tsx
+++ b/app/legal/privacidad/page.tsx
@@ -1,9 +1,9 @@
 ﻿export default function Privacidad(){
   return (
-    <main className="max-w-3xl mx-auto py-10">
-      <h1 className="text-3xl font-semibold">Política de Privacidad</h1>
-      <p className="mt-3 text-neutral-700">Tratamiento de datos conforme a Ley N.º 29733. Finalidades: pedidos, facturación, envíos y soporte. Conservación: la necesaria para obligaciones legales/comerciales. Derechos ARCO: a solicitud del titular.</p>
-      <p className="mt-6 text-sm text-neutral-500">Versión piloto — se ajustará con asesoría legal.</p>
+    <main className="mx-auto max-w-3xl py-10 text-night-foreground">
+      <h1 className="text-3xl font-semibold text-white">Política de Privacidad</h1>
+      <p className="mt-3 text-night-muted">Tratamiento de datos conforme a Ley N.º 29733. Finalidades: pedidos, facturación, envíos y soporte. Conservación: la necesaria para obligaciones legales/comerciales. Derechos ARCO: a solicitud del titular.</p>
+      <p className="mt-6 text-sm text-night-subtle">Versión piloto — se ajustará con asesoría legal.</p>
     </main>
   )
 }

--- a/app/legal/terminos/page.tsx
+++ b/app/legal/terminos/page.tsx
@@ -1,14 +1,14 @@
 ﻿export default function Terminos(){
   return (
-    <main className="max-w-3xl mx-auto py-10">
-      <h1 className="text-3xl font-semibold">Términos y Condiciones</h1>
-      <ul className="list-disc pl-5 mt-3 text-neutral-700 space-y-2">
+    <main className="mx-auto max-w-3xl py-10 text-night-foreground">
+      <h1 className="text-3xl font-semibold text-white">Términos y Condiciones</h1>
+      <ul className="mt-3 list-disc space-y-2 pl-5 text-night-muted">
         <li>Venta exclusiva para mayores de 18 años.</li>
         <li>Precios en PEN con IGV; sujeto a stock.</li>
         <li>Entrega discreta; tiempos según operador logístico.</li>
         <li>Prohibido revender sin autorización.</li>
       </ul>
-      <p className="mt-6 text-sm text-neutral-500">Versión piloto.</p>
+      <p className="mt-6 text-sm text-night-subtle">Versión piloto.</p>
     </main>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -97,7 +97,7 @@ export default function Page() {
     <>
       <Hero />
       <div className="mt-8 lg:hidden">
-        <HeroCarousel className="bg-white/70" />
+        <HeroCarousel className="shadow-neon" />
       </div>
       <div className="mt-10 space-y-12">
         <TrustBadgesStrip badges={TRUST_BADGES} />
@@ -112,7 +112,7 @@ export default function Page() {
             <div className="flex justify-end">
               <Link
                 href="/categorias"
-                className="inline-flex items-center rounded-full border border-neutral-200 bg-white px-5 py-2 text-sm font-semibold text-neutral-700 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900"
+                className="inline-flex items-center rounded-full border border-night-border bg-night-surface px-5 py-2 text-sm font-semibold text-night-foreground shadow-neon-sm transition hover:-translate-y-0.5 hover:shadow-neon focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
               >
                 Ver más categorías
               </Link>
@@ -175,10 +175,10 @@ export default function Page() {
         )}
         {normalizedOtherCategories.length > 0 && (
           <section className="space-y-4">
-            <h2 id="buscas-algo-mas-especifico" className="text-xl font-semibold text-neutral-900">
+            <h2 id="buscas-algo-mas-especifico" className="text-xl font-semibold text-white">
               ¿Buscas algo más específico?
             </h2>
-            <p className="text-sm text-neutral-600">
+            <p className="text-sm text-night-muted">
               Recorre las categorías sensibles y temáticas creadas para diferentes niveles de experiencia.
             </p>
             <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3">

--- a/components/AgeGate.tsx
+++ b/components/AgeGate.tsx
@@ -8,16 +8,25 @@ export function AgeGate() {
   }, [])
   if (!show) return null
   return (
-    <div className="fixed inset-0 z-[60] bg-white/70 backdrop-blur-sm flex items-center justify-center p-6">
-      <div className="bg-white p-6 rounded-2xl max-w-md text-center shadow-lg">
-        <h2 className="text-xl font-semibold">Contenido para mayores de 18 años</h2>
-        <p className="text-sm text-neutral-600 mt-2">Al continuar confirma ser mayor de edad.</p>
-        <div className="mt-4 flex justify-center gap-3">
-          <button onClick={() => { document.cookie = 'age_ok=1; path=/; max-age=31536000'; setShow(false) }}
-                  className="px-4 py-2 rounded-xl bg-brand-primary text-white">Tengo 18+</button>
-          <a href="https://www.google.com" className="px-4 py-2 rounded-xl border">Salir</a>
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-[color:rgba(3,0,15,0.82)] p-6 backdrop-blur-xl">
+      <div className="max-w-md rounded-2xl border border-night-border bg-night-surface-strong/95 p-6 text-center text-night-foreground shadow-neon">
+        <h2 className="text-xl font-semibold text-white drop-shadow-neon">Contenido para mayores de 18 años</h2>
+        <p className="mt-2 text-sm text-night-muted">Al continuar confirma ser mayor de edad.</p>
+        <div className="mt-5 flex justify-center gap-3">
+          <button
+            onClick={() => { document.cookie = 'age_ok=1; path=/; max-age=31536000'; setShow(false) }}
+            className="rounded-xl bg-gradient-to-r from-fuchsia-500 to-purple-500 px-5 py-2 text-sm font-semibold text-white shadow-neon transition hover:from-fuchsia-400 hover:to-purple-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
+          >
+            Tengo 18+
+          </button>
+          <a
+            href="https://www.google.com"
+            className="rounded-xl border border-night-border px-5 py-2 text-sm font-semibold text-night-foreground/80 transition hover:border-night-border-strong hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
+          >
+            Salir
+          </a>
         </div>
-        <p className="text-[11px] mt-3 text-neutral-500">El robot de Google puede rastrear el contenido para evaluación de políticas.</p>
+        <p className="mt-4 text-[11px] text-night-subtle">El robot de Google puede rastrear el contenido para evaluación de políticas.</p>
       </div>
     </div>
   )

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,13 +1,13 @@
 ﻿import Link from 'next/link'
 export default function Footer(){
   return (
-    <footer className="border-t mt-8">
-      <div className="max-w-6xl mx-auto px-4 py-6 text-sm text-neutral-600 flex flex-col md:flex-row gap-2 md:gap-6">
+    <footer className="mt-8 border-t border-night-border bg-night-surface backdrop-blur">
+      <div className="mx-auto flex max-w-6xl flex-col gap-2 px-4 py-6 text-sm text-night-subtle md:flex-row md:gap-6">
         <div className="flex-1">© {new Date().getFullYear()} SexShop del Perú 69</div>
-        <nav className="flex gap-4">
-          <Link href="/legal/privacidad">Privacidad</Link>
-          <Link href="/legal/terminos">Términos</Link>
-          <Link href="/legal/devoluciones">Devoluciones</Link>
+        <nav className="flex gap-4 text-night-foreground/80">
+          <Link className="transition hover:text-white" href="/legal/privacidad">Privacidad</Link>
+          <Link className="transition hover:text-white" href="/legal/terminos">Términos</Link>
+          <Link className="transition hover:text-white" href="/legal/devoluciones">Devoluciones</Link>
         </nav>
       </div>
     </footer>

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -116,7 +116,7 @@ export default function ProductCard({ p, highlightBadge }: ProductCardProps) {
         <motion.a
           {...({
             href: `/producto/${p.slug}`,
-            className: 'group block overflow-hidden rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm',
+            className: 'group block overflow-hidden rounded-2xl border border-night-border bg-night-surface/95 p-4 text-night-foreground shadow-neon-sm transition-shadow hover:shadow-neon',
             whileHover: { y: -4 },
             whileTap: { scale: 0.98 },
             transition: { type: 'spring', stiffness: 300, damping: 20, mass: 0.6 },
@@ -126,14 +126,14 @@ export default function ProductCard({ p, highlightBadge }: ProductCardProps) {
             onTouchMove: handleTouchMove
           } as unknown as HTMLMotionProps<'a'>)}
         >
-          <div className="relative aspect-[4/3] rounded-2xl border border-neutral-200 bg-neutral-100 p-4">
+          <div className="relative aspect-[4/3] rounded-2xl border border-night-border bg-night-surface-strong/80 p-4">
             <div className="relative h-full w-full overflow-hidden rounded-xl">
               <div
-                className="absolute inset-0 bg-gradient-to-br from-brand-primary/10 via-transparent to-brand-accent/20 opacity-0 transition group-hover:opacity-100"
+                className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(236,72,153,0.25),_transparent_65%)] opacity-0 transition group-hover:opacity-100"
                 aria-hidden
               />
               {displayBadge && (
-                <div className="absolute left-2.5 top-2.5 inline-flex items-center rounded-full bg-neutral-900/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white shadow-lg">
+                <div className="absolute left-2.5 top-2.5 inline-flex items-center rounded-full bg-fuchsia-500/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white shadow-neon-sm">
                   {displayBadge}
                 </div>
               )}
@@ -152,14 +152,14 @@ export default function ProductCard({ p, highlightBadge }: ProductCardProps) {
             </div>
           </div>
           <div className="mt-3 space-y-1">
-            <div className="line-clamp-2 font-medium text-neutral-900">{p.name}</div>
+            <div className="line-clamp-2 font-medium text-night-foreground">{p.name}</div>
             <div className="flex items-baseline gap-2">
-              <span className="font-semibold text-brand-primary">S/ {displayPrice}</span>
+              <span className="font-semibold text-fuchsia-200 drop-shadow-neon">S/ {displayPrice}</span>
               {hasSalePrice && (
-                <span className="text-sm font-medium text-neutral-400 line-through">S/ {regularPrice}</span>
+                <span className="text-sm font-medium text-night-muted line-through">S/ {regularPrice}</span>
               )}
             </div>
-            {p.brand && <div className="text-xs uppercase tracking-wide text-neutral-500">{p.brand}</div>}
+            {p.brand && <div className="text-xs uppercase tracking-wide text-night-subtle">{p.brand}</div>}
           </div>
         </motion.a>
       </Link>
@@ -167,7 +167,7 @@ export default function ProductCard({ p, highlightBadge }: ProductCardProps) {
       <div className="pointer-events-none absolute inset-x-6 bottom-6 flex justify-center">
         <button
           type="button"
-          className="pointer-events-auto inline-flex items-center gap-2 rounded-full bg-neutral-900/90 px-4 py-2 text-sm font-medium text-white shadow-lg transition hover:bg-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+          className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-night-border-strong bg-night-surface-strong/90 px-4 py-2 text-sm font-medium text-white shadow-neon-sm transition hover:border-fuchsia-400/60 hover:text-fuchsia-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
           onClick={() => setIsQuickViewOpen(true)}
         >
           Vista rápida

--- a/components/StickyCTA.tsx
+++ b/components/StickyCTA.tsx
@@ -14,7 +14,7 @@ type StickyCTAProps = {
 const MotionContainer = motion<{ className?: string; style?: CSSProperties }>('div')
 
 export default function StickyCTA({ price, regularPrice, checkoutHref, whatsappHref }: StickyCTAProps) {
-  const containerClassName = 'fixed inset-x-0 bottom-0 z-50 bg-gradient-to-t from-white via-white/95 to-white/20 pb-4 pt-2 md:hidden'
+  const containerClassName = 'fixed inset-x-0 bottom-0 z-50 bg-gradient-to-t from-[rgba(5,0,15,0.95)] via-[rgba(10,0,30,0.8)] to-transparent pb-4 pt-2 md:hidden'
   const containerStyle: CSSProperties = {
     paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 1rem)'
   }
@@ -31,20 +31,20 @@ export default function StickyCTA({ price, regularPrice, checkoutHref, whatsappH
       style={containerStyle}
     >
       <div className="mx-auto mb-4 w-full max-w-md px-4">
-        <div className="rounded-3xl border border-neutral-200 bg-white/95 p-4 shadow-xl backdrop-blur">
-          <div className="flex items-baseline justify-between text-neutral-900">
-            <span className="text-xs uppercase tracking-wide text-neutral-500">Total estimado</span>
-            <span className="flex items-baseline gap-2 text-lg font-semibold">
+        <div className="rounded-3xl border border-night-border bg-night-surface/95 p-4 text-night-foreground shadow-neon backdrop-blur">
+          <div className="flex items-baseline justify-between">
+            <span className="text-xs uppercase tracking-wide text-night-muted">Total estimado</span>
+            <span className="flex items-baseline gap-2 text-lg font-semibold text-white">
               <span>S/ {displayPrice}</span>
               {formattedRegularPrice && (
-                <span className="text-sm font-medium text-neutral-400 line-through">S/ {formattedRegularPrice}</span>
+                <span className="text-sm font-medium text-night-muted line-through">S/ {formattedRegularPrice}</span>
               )}
             </span>
           </div>
           <div className="mt-3 grid grid-cols-2 gap-2">
             <Link
               href={checkoutHref}
-              className="group inline-flex flex-col items-center justify-center gap-1 rounded-2xl bg-brand-primary px-4 py-3 text-center text-white shadow-lg transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+              className="group inline-flex flex-col items-center justify-center gap-1 rounded-2xl bg-gradient-to-r from-fuchsia-500 to-purple-500 px-4 py-3 text-center text-white shadow-neon transition-all duration-200 hover:-translate-y-0.5 hover:shadow-neon focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
             >
               <span className="text-sm font-semibold">Comprar ahora</span>
               <span className="text-[11px] text-white/80">Pago cifrado y discreto</span>
@@ -53,10 +53,10 @@ export default function StickyCTA({ price, regularPrice, checkoutHref, whatsappH
               href={whatsappHref}
               target="_blank"
               rel="noreferrer"
-              className="group inline-flex flex-col items-center justify-center gap-1 rounded-2xl border border-brand-primary/30 bg-white px-4 py-3 text-center text-brand-primary shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-brand-primary/50 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+              className="group inline-flex flex-col items-center justify-center gap-1 rounded-2xl border border-night-border bg-night-surface px-4 py-3 text-center text-night-foreground shadow-neon-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-night-border-strong hover:shadow-neon focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
             >
               <span className="text-sm font-semibold">WhatsApp 24/7</span>
-              <span className="text-[11px] text-brand-primary/80">Respuesta inmediata</span>
+              <span className="text-[11px] text-night-muted">Respuesta inmediata</span>
             </a>
           </div>
         </div>

--- a/components/home/BestSellers.tsx
+++ b/components/home/BestSellers.tsx
@@ -91,16 +91,16 @@ export default function BestSellers({
       >
         <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
           <div>
-            <h2 id={headingId} className="text-2xl font-semibold text-neutral-900">
+            <h2 id={headingId} className="text-2xl font-semibold text-white">
               {title}
             </h2>
-            <p className="text-sm text-neutral-600">{description}</p>
+            <p className="text-sm text-night-muted">{description}</p>
           </div>
           {ctaHref && (
             <Link
               href={ctaHref}
               role="button"
-              className="group inline-flex items-center gap-2 self-start text-sm font-semibold text-brand-primary transition-colors hover:text-brand-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+              className="group inline-flex items-center gap-2 self-start text-sm font-semibold text-fuchsia-200 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
             >
               {ctaLabel}
               <ArrowRight aria-hidden className="size-4 transition-transform group-hover:translate-x-1" />
@@ -111,11 +111,11 @@ export default function BestSellers({
       {layout === 'carousel' ? (
         <div className="relative">
           <div
-            className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-white via-white/60 to-transparent"
+            className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-night-surface via-night-surface/80 to-transparent"
             aria-hidden
           />
           <div
-            className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-white via-white/60 to-transparent"
+            className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-night-surface via-night-surface/80 to-transparent"
             aria-hidden
           />
           <div
@@ -148,8 +148,8 @@ export default function BestSellers({
               onClick={() => scrollBy('left')}
               disabled={!canScrollLeft}
               aria-label="Ver productos anteriores"
-              className={`pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full border border-neutral-200 bg-white/90 text-neutral-900 shadow-lg transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900 ${
-                canScrollLeft ? 'hover:bg-white' : 'cursor-not-allowed opacity-50'
+              className={`pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full border border-night-border bg-night-surface-strong/80 text-night-foreground shadow-neon-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300 ${
+                canScrollLeft ? 'hover:border-night-border-strong hover:text-white' : 'cursor-not-allowed opacity-40'
               }`}
             >
               <ChevronLeft className="h-4 w-4" aria-hidden />
@@ -159,8 +159,8 @@ export default function BestSellers({
               onClick={() => scrollBy('right')}
               disabled={!canScrollRight}
               aria-label="Ver productos siguientes"
-              className={`pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full border border-neutral-200 bg-white/90 text-neutral-900 shadow-lg transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900 ${
-                canScrollRight ? 'hover:bg-white' : 'cursor-not-allowed opacity-50'
+              className={`pointer-events-auto flex h-11 w-11 items-center justify-center rounded-full border border-night-border bg-night-surface-strong/80 text-night-foreground shadow-neon-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300 ${
+                canScrollRight ? 'hover:border-night-border-strong hover:text-white' : 'cursor-not-allowed opacity-40'
               }`}
             >
               <ChevronRight className="h-4 w-4" aria-hidden />

--- a/components/home/CategoryCarousel.tsx
+++ b/components/home/CategoryCarousel.tsx
@@ -46,12 +46,12 @@ export function CategoryCard({ category, href = `/categoria/${category.slug}` }:
   return (
     <Link href={href} className="group block h-full">
       <MotionArticle
-        whileHover={{ y: -6, boxShadow: '0 18px 30px -16px rgba(15,23,42,0.35)' }}
+        whileHover={{ y: -6, boxShadow: '0 22px 38px -18px rgba(236,72,153,0.45)' }}
         transition={{ type: 'spring', stiffness: 260, damping: 20 }}
-        className="flex h-full min-h-[280px] w-full flex-col overflow-hidden rounded-2xl border border-neutral-200 bg-white text-left shadow-lg"
+        className="flex h-full min-h-[280px] w-full flex-col overflow-hidden rounded-2xl border border-night-border bg-night-surface/95 text-left text-night-foreground shadow-neon-sm"
       >
         {category.image ? (
-          <div className="relative h-40 w-full overflow-hidden rounded-t-2xl bg-neutral-100">
+          <div className="relative h-40 w-full overflow-hidden rounded-t-2xl bg-night-surface-strong/80">
             <Image
               src={category.image}
               alt={`${category.label} — miniatura de categoría`}
@@ -61,14 +61,14 @@ export function CategoryCard({ category, href = `/categoria/${category.slug}` }:
             />
           </div>
         ) : (
-          <div className="flex h-40 w-full items-center justify-center rounded-t-2xl bg-neutral-100 text-xs font-semibold uppercase tracking-[0.08em] text-neutral-500">
+          <div className="flex h-40 w-full items-center justify-center rounded-t-2xl bg-night-surface-strong/80 text-xs font-semibold uppercase tracking-[0.08em] text-night-muted">
             Explorar categoría
           </div>
         )}
         <div className="flex flex-1 flex-col gap-1 px-5 pb-6 pt-4">
-          <h3 className="text-lg font-extrabold uppercase text-neutral-900">{category.label}</h3>
-          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-neutral-500">{category.subtitle}</p>
-          <p className="text-sm font-semibold uppercase text-neutral-600">{category.description}</p>
+          <h3 className="text-lg font-extrabold uppercase text-white">{category.label}</h3>
+          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-night-muted">{category.subtitle}</p>
+          <p className="text-sm font-semibold uppercase text-night-subtle">{category.description}</p>
         </div>
       </MotionArticle>
     </Link>
@@ -116,10 +116,10 @@ export default function CategoryCarousel({ title, subtitle, headingId, categorie
     <section className="space-y-4" id="catalogo">
       {title && (
         <div className="space-y-1">
-          <h2 id={headingId} className="text-xl font-semibold text-neutral-900">
+          <h2 id={headingId} className="text-xl font-semibold text-white">
             {title}
           </h2>
-          {subtitle && <p className="text-sm text-neutral-600">{subtitle}</p>}
+          {subtitle && <p className="text-sm text-night-muted">{subtitle}</p>}
         </div>
       )}
       <div
@@ -148,9 +148,9 @@ export default function CategoryCarousel({ title, subtitle, headingId, categorie
           <MotionCard className="min-w-[200px] max-w-[220px] snap-start">
             <Link href="/categoria" className="block h-full">
               <MotionArticle
-                whileHover={{ y: -6, boxShadow: '0 18px 30px -16px rgba(15,23,42,0.35)' }}
+                whileHover={{ y: -6, boxShadow: '0 22px 38px -18px rgba(236,72,153,0.45)' }}
                 transition={{ type: 'spring', stiffness: 260, damping: 20 }}
-                className="flex h-full min-h-[280px] w-full flex-col items-center justify-center rounded-2xl border border-dashed border-neutral-300 bg-white text-center font-semibold uppercase text-neutral-700 shadow-lg"
+                className="flex h-full min-h-[280px] w-full flex-col items-center justify-center rounded-2xl border border-dashed border-night-border bg-night-surface/90 text-center font-semibold uppercase text-night-foreground/80 shadow-neon-sm"
               >
                 Ver todas
               </MotionArticle>
@@ -165,9 +165,9 @@ export default function CategoryCarousel({ title, subtitle, headingId, categorie
         {remainingCategories.length > 0 && (
           <Link href="/categoria" className="block h-full">
             <MotionArticle
-              whileHover={{ y: -6, boxShadow: '0 18px 30px -16px rgba(15,23,42,0.35)' }}
+              whileHover={{ y: -6, boxShadow: '0 22px 38px -18px rgba(236,72,153,0.45)' }}
               transition={{ type: 'spring', stiffness: 260, damping: 20 }}
-              className="flex h-full min-h-[280px] w-full flex-col items-center justify-center rounded-2xl border border-dashed border-neutral-300 bg-white text-center font-semibold uppercase text-neutral-700 shadow-lg"
+              className="flex h-full min-h-[280px] w-full flex-col items-center justify-center rounded-2xl border border-dashed border-night-border bg-night-surface/90 text-center font-semibold uppercase text-night-foreground/80 shadow-neon-sm"
             >
               Ver más categorías
             </MotionArticle>

--- a/components/home/FeaturedProducts.tsx
+++ b/components/home/FeaturedProducts.tsx
@@ -29,10 +29,10 @@ export default function FeaturedProducts({ products, headingId }: FeaturedProduc
   return (
     <section className="space-y-8" aria-labelledby={headingId}>
       <div className="space-y-2">
-        <h2 id={headingId} className="text-3xl font-semibold text-neutral-900">
+        <h2 id={headingId} className="text-3xl font-semibold text-white">
           Productos destacados
         </h2>
-        <p className="max-w-2xl text-sm text-neutral-600">
+        <p className="max-w-2xl text-sm text-night-muted">
           Piezas de lujo seleccionadas para experiencias intensas, con materiales premium, embalaje discreto y soporte experto.
         </p>
       </div>
@@ -54,14 +54,14 @@ export default function FeaturedProducts({ products, headingId }: FeaturedProduc
           return (
             <motion.article
               key={product.slug}
-              className="group relative overflow-hidden rounded-[2rem] border border-neutral-200 bg-gradient-to-br from-white via-white to-neutral-50 shadow-xl"
+              className="group relative overflow-hidden rounded-[2rem] border border-night-border bg-gradient-to-br from-[#3b0a5a]/40 via-night-surface to-[#12002e]/90 text-night-foreground shadow-neon"
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true, amount: 0.2 }}
               transition={{ delay: index * 0.05, duration: 0.45, ease: 'easeOut' }}
             >
               <div className="relative h-72 overflow-hidden">
-                <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(126,34,206,0.15),_transparent_60%)] opacity-0 transition group-hover:opacity-100" aria-hidden />
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(236,72,153,0.25),_transparent_65%)] opacity-0 transition group-hover:opacity-100" aria-hidden />
                 <Image
                   src={imageSrc}
                   alt={product.name}
@@ -72,23 +72,23 @@ export default function FeaturedProducts({ products, headingId }: FeaturedProduc
               </div>
               <div className="relative space-y-4 p-8">
                 <div className="space-y-2">
-                  <span className="inline-flex items-center rounded-full bg-neutral-900/90 px-4 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-white">Premium</span>
-                  <h3 className="text-2xl font-semibold text-neutral-900">{product.name}</h3>
+                  <span className="inline-flex items-center rounded-full bg-fuchsia-500/90 px-4 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-white shadow-neon-sm">Premium</span>
+                  <h3 className="text-2xl font-semibold text-white">{product.name}</h3>
                   {product.shortDescription && (
-                    <p className="text-sm leading-relaxed text-neutral-600">{product.shortDescription}</p>
+                    <p className="text-sm leading-relaxed text-night-muted">{product.shortDescription}</p>
                   )}
                 </div>
                 <div className="flex flex-wrap items-center justify-between gap-4">
-                  <span className="text-lg font-semibold text-brand-primary">S/ {price}</span>
+                  <span className="text-lg font-semibold text-fuchsia-200 drop-shadow-neon">S/ {price}</span>
                   <Link
                     href={`/producto/${product.slug}`}
-                    className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-2.5 text-sm font-semibold text-white shadow-lg shadow-neutral-900/40 transition hover:bg-neutral-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900"
+                    className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-fuchsia-500 to-purple-500 px-6 py-2.5 text-sm font-semibold text-white shadow-neon transition hover:from-fuchsia-400 hover:to-purple-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
                   >
                     Comprar ahora
                   </Link>
                 </div>
               </div>
-              <div className="pointer-events-none absolute inset-0 border border-white/20 mix-blend-overlay" aria-hidden />
+              <div className="pointer-events-none absolute inset-0 border border-night-border-strong/60 mix-blend-screen" aria-hidden />
             </motion.article>
           )
         })}

--- a/components/home/HeroCarousel.tsx
+++ b/components/home/HeroCarousel.tsx
@@ -72,11 +72,11 @@ type HeroCarouselProps = {
 }
 
 const baseButtonClasses =
-  'inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900'
+  'inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300'
 const primaryButtonClasses =
-  `${baseButtonClasses} bg-neutral-900 text-white shadow-md shadow-neutral-900/30 hover:bg-neutral-800`
+  `${baseButtonClasses} bg-gradient-to-r from-fuchsia-500 to-purple-500 text-white shadow-neon hover:from-fuchsia-400 hover:to-purple-400`
 const secondaryButtonClasses =
-  `${baseButtonClasses} border border-neutral-900/20 bg-white/70 text-neutral-900 hover:border-neutral-900/50`
+  `${baseButtonClasses} border border-night-border bg-transparent text-night-foreground/80 hover:border-night-border-strong hover:text-white`
 type SlideMotionProps = HTMLMotionProps<'div'> & { className?: string }
 
 const SlideMotion = forwardRef<HTMLDivElement, SlideMotionProps>((props, ref) => <motion.div ref={ref} {...props} />)
@@ -133,7 +133,7 @@ export default function HeroCarousel({
   const activeSlide = slides[activeIndex]
 
   const containerClasses = [
-    'relative overflow-hidden rounded-3xl border border-white/10 bg-white/70 p-6 shadow-sm backdrop-blur lg:p-10',
+    'relative overflow-hidden rounded-3xl border border-night-border bg-night-surface p-6 text-night-foreground shadow-neon-sm backdrop-blur lg:p-10',
     className
   ]
     .filter(Boolean)
@@ -155,13 +155,13 @@ export default function HeroCarousel({
       onBlurCapture={handleBlurCapture}
     >
       <div className="flex items-center justify-between">
-        <div className="text-xs font-semibold uppercase tracking-[0.3em] text-neutral-500">{activeSlide.tag}</div>
+        <div className="text-xs font-semibold uppercase tracking-[0.3em] text-night-muted">{activeSlide.tag}</div>
         <div className="flex items-center gap-2">
           <button
             type="button"
             onClick={handlePrevious}
             aria-label="Ver destacado anterior"
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-neutral-900/15 bg-white/60 text-neutral-900 transition hover:border-neutral-900/40 hover:text-neutral-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-night-border bg-night-surface-strong/80 text-night-foreground shadow-neon-sm transition hover:border-night-border-strong hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
           >
             <ChevronLeft className="h-4 w-4" aria-hidden />
           </button>
@@ -169,7 +169,7 @@ export default function HeroCarousel({
             type="button"
             onClick={handleNext}
             aria-label="Ver siguiente destacado"
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-neutral-900/15 bg-white/60 text-neutral-900 transition hover:border-neutral-900/40 hover:text-neutral-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-night-border bg-night-surface-strong/80 text-night-foreground shadow-neon-sm transition hover:border-night-border-strong hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
           >
             <ChevronRight className="h-4 w-4" aria-hidden />
           </button>
@@ -189,10 +189,10 @@ export default function HeroCarousel({
             <div aria-live="polite" className="contents">
               <div className="space-y-6">
                 <div className="space-y-3">
-                  <h2 className="text-2xl font-semibold text-neutral-900 sm:text-3xl lg:text-[2.4rem] lg:leading-[1.05]">
+                  <h2 className="text-2xl font-semibold text-white sm:text-3xl lg:text-[2.4rem] lg:leading-[1.05]">
                     {activeSlide.title}
                   </h2>
-                  <p className="text-sm leading-relaxed text-neutral-600 sm:text-base">{activeSlide.description}</p>
+                  <p className="text-sm leading-relaxed text-night-muted sm:text-base">{activeSlide.description}</p>
                 </div>
 
                 <div className="flex flex-wrap gap-3">
@@ -205,7 +205,7 @@ export default function HeroCarousel({
                 </div>
               </div>
 
-              <div className="relative aspect-[4/3] w-full overflow-hidden rounded-2xl border border-white/40 bg-gradient-to-br from-[#7f00ff]/20 via-transparent to-[#ff6f91]/20">
+              <div className="relative aspect-[4/3] w-full overflow-hidden rounded-2xl border border-night-border bg-gradient-to-br from-[#7f00ff]/25 via-transparent to-[#ff6f91]/25">
                 <Image
                   src={activeSlide.image}
                   alt={activeSlide.title}
@@ -221,7 +221,7 @@ export default function HeroCarousel({
         </AnimatePresence>
       </div>
 
-      <div className="mt-6 flex flex-wrap items-center justify-between gap-4 text-xs text-neutral-500">
+      <div className="mt-6 flex flex-wrap items-center justify-between gap-4 text-xs text-night-muted">
         <div className="flex items-center gap-2">
           {slides.map((slide, index) => {
             const isActive = index === activeIndex
@@ -230,7 +230,7 @@ export default function HeroCarousel({
                 key={slide.id}
                 type="button"
                 onClick={() => goTo(index)}
-                className={`h-2.5 rounded-full transition ${isActive ? 'w-7 bg-neutral-900' : 'w-2.5 bg-neutral-400/50 hover:bg-neutral-500/70'}`}
+                className={`h-2.5 rounded-full transition ${isActive ? 'w-7 bg-fuchsia-400' : 'w-2.5 bg-night-subtle/50 hover:bg-night-subtle'}`}
                 aria-label={`Ir a la diapositiva: ${slide.title}`}
                 aria-current={isActive ? 'true' : 'false'}
               />

--- a/components/home/InspirationalBanner.tsx
+++ b/components/home/InspirationalBanner.tsx
@@ -29,24 +29,24 @@ export default function InspirationalBanner({
     <div className="relative h-64 overflow-hidden rounded-[2.25rem] lg:h-full">
       <Image src={image} alt={imageAlt} fill className="object-cover" sizes="(min-width: 1024px) 50vw, 100vw" />
       <div
-        className="absolute inset-0 bg-gradient-to-br from-brand-primary/20 via-transparent to-brand-accent/30 mix-blend-multiply"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(236,72,153,0.25),_transparent_70%)] mix-blend-screen"
         aria-hidden
       />
     </div>
   )
 
   const contentElement = (
-    <div className="flex flex-col justify-center gap-6 px-8 py-10">
-      {eyebrow && <span className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-primary">{eyebrow}</span>}
+    <div className="flex flex-col justify-center gap-6 px-8 py-10 text-night-foreground">
+      {eyebrow && <span className="text-xs font-semibold uppercase tracking-[0.35em] text-night-muted">{eyebrow}</span>}
       <div className="space-y-4">
-        <h3 className="text-3xl font-semibold text-neutral-900">{title}</h3>
-        <p className="text-base leading-relaxed text-neutral-600">{description}</p>
+        <h3 className="text-3xl font-semibold text-white">{title}</h3>
+        <p className="text-base leading-relaxed text-night-muted">{description}</p>
       </div>
       {ctaHref && ctaLabel && (
         <div>
           <Link
             href={ctaHref}
-            className="inline-flex items-center justify-center rounded-full bg-neutral-900 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-neutral-900/30 transition hover:bg-neutral-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900"
+            className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-fuchsia-500 to-purple-500 px-6 py-3 text-sm font-semibold text-white shadow-neon transition hover:from-fuchsia-400 hover:to-purple-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
           >
             {ctaLabel}
           </Link>
@@ -61,7 +61,7 @@ export default function InspirationalBanner({
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.3 }}
       transition={{ duration: 0.6, ease: 'easeOut' }}
-      className="relative overflow-hidden rounded-[2.25rem] border border-neutral-200 bg-white shadow-[0_30px_80px_-40px_rgba(126,34,206,0.35)]"
+      className="relative overflow-hidden rounded-[2.25rem] border border-night-border bg-night-surface text-night-foreground shadow-neon"
     >
       <div className="grid gap-8 lg:grid-cols-2">
         {align === 'left' ? (

--- a/components/home/TrustBadgesStrip.tsx
+++ b/components/home/TrustBadgesStrip.tsx
@@ -26,14 +26,14 @@ export default function TrustBadgesStrip({ badges }: TrustBadgesStripProps) {
           initial={{ opacity: 0, y: 12 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: index * 0.08, duration: 0.35, ease: 'easeOut' }}
-          className="flex items-center gap-3 rounded-2xl border border-neutral-200 bg-white/80 px-4 py-3 shadow-sm backdrop-blur"
+          className="flex items-center gap-3 rounded-2xl border border-night-border bg-night-surface/95 px-4 py-3 shadow-neon-sm backdrop-blur"
         >
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-primary/10 text-brand-primary">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-fuchsia-500/20 text-fuchsia-200">
             {badge.icon}
           </div>
           <div>
-            <div className="text-sm font-semibold text-neutral-900">{badge.label}</div>
-            {badge.description && <p className="text-xs text-neutral-600">{badge.description}</p>}
+            <div className="text-sm font-semibold text-white">{badge.label}</div>
+            {badge.description && <p className="text-xs text-night-muted">{badge.description}</p>}
           </div>
         </MotionBadge>
       ))}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,7 +17,28 @@ export default {
           accent: '#9B51E0',
           warn: '#FFD600',
           electric: '#00AEEF',
+        },
+        night: {
+          background: '#05000f',
+          foreground: '#f7f2ff',
+          muted: '#cbbdf5',
+          subtle: '#a99eda',
+          surface: '#1a062b',
+          'surface-strong': '#170629',
+          border: 'rgba(219, 196, 255, 0.25)',
+          'border-strong': 'rgba(236, 208, 255, 0.45)'
         }
+      },
+      backgroundImage: {
+        'night-radial':
+          'radial-gradient(circle at 15% 15%, rgba(236,72,153,0.28), transparent 55%), radial-gradient(circle at 85% 20%, rgba(56,189,248,0.18), transparent 50%), linear-gradient(135deg, #05000f 0%, #0d0121 45%, #1a0235 100%)'
+      },
+      boxShadow: {
+        'neon-sm': '0 18px 35px -16px rgba(236,72,153,0.45), 0 8px 24px -12px rgba(59,130,246,0.35)',
+        neon: '0 35px 60px -25px rgba(168,85,247,0.55), 0 0 45px rgba(236,72,153,0.35)'
+      },
+      dropShadow: {
+        neon: '0 0 12px rgba(236,72,153,0.55)'
       },
       borderRadius: {
         xl2: '1.25rem'


### PR DESCRIPTION
## Summary
- introduce a neon night gradient background plus dark theme tokens for the layout
- refresh key landing components with neon surfaces, hover shadows, and high-contrast typography
- ensure age gate and legal pages stay legible on the new dark scheme

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d336ef899c8321aac97a7bde3ba7b1