### PR TITLE
feat: refresh home palette with branded imagery

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { PackageCheck, ShieldCheck, LockKeyhole } from 'lucide-react'
+import Image from 'next/image'
 import Link from 'next/link'
 import Hero from '@/components/Hero'
 import { allProducts, getBestSellers, getNewArrivals, getOffers } from '@/lib/products'
@@ -90,105 +91,180 @@ export default function Page() {
     description: category.isSensitive ? 'Contenido sensible (18+)' : 'Explorar con seguridad',
     subtitle: category.isSensitive ? 'Contenido adulto' : 'Bienestar y cuidado'
   }))
-  const carouselCategories = featured.length > 0 ? featured : availableCategories
-
-
   return (
     <>
       <Hero />
-      <div className="mt-8 lg:hidden">
-        <HeroCarousel className="shadow-neon" />
-      </div>
-      <div className="mt-10 space-y-12">
-        <TrustBadgesStrip badges={TRUST_BADGES} />
-        <section className="space-y-6" id="catalogo">
-          <CategoryCarousel
-            title="Explora por categoría"
-            subtitle="Mobile-first con desliz lateral — arrastra para descubrir más."
-            headingId="explora-por-categoria"
-            categories={highlightedCategories}
-          />
-          {hasMoreCategories && (
-            <div className="flex justify-end">
-              <Link
-                href="/categorias"
-                className="inline-flex items-center rounded-full border border-night-border bg-night-surface px-5 py-2 text-sm font-semibold text-night-foreground shadow-neon-sm transition hover:-translate-y-0.5 hover:shadow-neon focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
-              >
-                Ver más categorías
-              </Link>
+      <div className="mt-12 space-y-16 lg:space-y-20">
+        <section className="relative overflow-hidden rounded-[3rem] border border-night-border/70 bg-night-radial px-6 py-12 sm:px-10 lg:px-16">
+          <div className="pointer-events-none absolute -left-28 bottom-[-5rem] hidden h-72 w-72 rounded-full bg-fuchsia-500/25 blur-3xl sm:block" aria-hidden />
+          <div className="pointer-events-none absolute -right-40 top-[-3rem] hidden h-[360px] w-[360px] rotate-[10deg] lg:block" aria-hidden>
+            <Image
+              src="/landing/vibrador-fondo-negro.webp"
+              alt=""
+              fill
+              className="object-cover object-center opacity-70 mix-blend-screen"
+              sizes="360px"
+              priority
+            />
+          </div>
+          <div className="relative z-10 space-y-10">
+            <TrustBadgesStrip badges={TRUST_BADGES} />
+            <div className="grid gap-10 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+              <div className="space-y-6" id="catalogo">
+                <CategoryCarousel
+                  title="Explora por categoría"
+                  subtitle="Mobile-first con desliz lateral — arrastra para descubrir más."
+                  headingId="explora-por-categoria"
+                  categories={highlightedCategories}
+                />
+                {hasMoreCategories && (
+                  <div className="flex justify-end">
+                    <Link
+                      href="/categorias"
+                      className="inline-flex items-center rounded-full border border-fuchsia-500/60 bg-black/60 px-5 py-2 text-sm font-semibold text-white shadow-neon-sm transition hover:-translate-y-0.5 hover:shadow-neon focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
+                    >
+                      Ver más categorías
+                    </Link>
+                  </div>
+                )}
+              </div>
+              <HeroCarousel className="h-full border border-night-border/60 bg-black/40 px-4 py-6 shadow-neon-sm backdrop-blur" />
             </div>
-          )}
+          </div>
         </section>
-        <FeaturedProducts products={premiumProducts} headingId="productos-destacados" />
-        <InspirationalBanner
-          eyebrow="Editorial 69"
-          title="Sensualidad consciente"
-          description="Eleva tus rituales íntimos con materiales hipoalergénicos, cosmética vegana y guías diseñadas por terapeutas certificados."
-          image="/hero/juguetes-anales-premium.svg"
-          imageAlt="Ilustración de juguetes premium en tonos metálicos"
-          ctaHref="/colecciones/wellness"
-          ctaLabel="Explorar rituales"
-        />
-        <BestSellers
-          products={bestSellers}
-          headingId="mas-vendidos"
-          layout="carousel"
-          maxVisible={6}
-        />
-        {newArrivals.length > 0 && (
-          <BestSellers
-            products={newArrivals}
-            headingId="nuevos-ingresos"
-            title="Novedades destacadas"
-            description="Lo último en llegar a nuestro catálogo, con lanzamientos recientes y reposiciones esperadas."
-            ctaHref="/categoria/novedades"
-            ctaLabel="Ver novedades"
-            highlightBadges={newArrivalHighlightBadges}
-            showBestSellerHighlight={false}
-            layout="carousel"
-            maxVisible={6}
+
+        <div className="relative overflow-hidden rounded-[3rem] border border-night-border/60 bg-gradient-to-br from-[#09000a] via-[#230017] to-[#340126] px-6 py-12 sm:px-10 lg:px-16">
+          <div className="pointer-events-none absolute inset-y-0 right-[-8%] hidden w-[45%] lg:block" aria-hidden>
+            <Image
+              src="/landing/chica-con-vibrador.webp"
+              alt=""
+              fill
+              className="object-cover object-center opacity-70 mix-blend-screen"
+              sizes="(min-width: 1024px) 40vw, 60vw"
+            />
+          </div>
+          <div className="pointer-events-none absolute -left-32 top-[-8rem] hidden h-80 w-80 rounded-full bg-fuchsia-500/30 blur-3xl sm:block" aria-hidden />
+          <div className="relative z-10">
+            <FeaturedProducts products={premiumProducts} headingId="productos-destacados" />
+          </div>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-2">
+          <InspirationalBanner
+            eyebrow="Editorial 69"
+            title="Sensualidad consciente"
+            description="Eleva tus rituales íntimos con materiales hipoalergénicos, cosmética vegana y guías diseñadas por terapeutas certificados."
+            image="/landing/vibrador-fondo-negro.webp"
+            imageAlt="Juguetes íntimos sobre fondo negro con destellos fucsias"
+            ctaHref="/colecciones/wellness"
+            ctaLabel="Explorar rituales"
+            tone="fuchsia"
+            imageAspect="portrait"
+            imagePriority
           />
-        )}
-        <InspirationalBanner
-          align="right"
-          eyebrow="Historias reales"
-          title="Parejas que experimentan"
-          description="Descubre testimonios curados y sesiones guiadas para sincronizar ritmos, explorar comunicación íntima y potenciar el deseo mutuo."
-          image="/hero/parejas-curiosas-neon.svg"
-          imageAlt="Ilustración futurista de pareja conectada"
-          ctaHref="/blog/parejas"
-          ctaLabel="Leer historias"
-        />
+          <InspirationalBanner
+            align="right"
+            eyebrow="Historias reales"
+            title="Parejas que experimentan"
+            description="Descubre testimonios curados y sesiones guiadas para sincronizar ritmos, explorar comunicación íntima y potenciar el deseo mutuo."
+            image="/landing/chico-mirando-anillo.webp"
+            imageAlt="Persona admirando un anillo vibrador en tonos morados"
+            ctaHref="/blog/parejas"
+            ctaLabel="Leer historias"
+            tone="night"
+            imageAspect="landscape"
+          />
+        </div>
+
+        <div className="relative overflow-hidden rounded-[3rem] border border-night-border/60 bg-[#120015]/90 px-6 py-12 sm:px-10 lg:px-16">
+          <div className="pointer-events-none absolute inset-y-0 right-[-12%] hidden w-[42%] lg:block" aria-hidden>
+            <Image
+              src="/landing/arnes-funda.webp"
+              alt=""
+              fill
+              className="object-cover object-center opacity-60 mix-blend-screen"
+              sizes="(min-width: 1024px) 35vw, 60vw"
+            />
+          </div>
+          <div className="relative z-10 space-y-12">
+            <BestSellers
+              products={bestSellers}
+              headingId="mas-vendidos"
+              layout="carousel"
+              maxVisible={6}
+            />
+            {newArrivals.length > 0 && (
+              <BestSellers
+                products={newArrivals}
+                headingId="nuevos-ingresos"
+                title="Novedades destacadas"
+                description="Lo último en llegar a nuestro catálogo, con lanzamientos recientes y reposiciones esperadas."
+                ctaHref="/categoria/novedades"
+                ctaLabel="Ver novedades"
+                highlightBadges={newArrivalHighlightBadges}
+                showBestSellerHighlight={false}
+                layout="carousel"
+                maxVisible={6}
+              />
+            )}
+          </div>
+        </div>
+
         {offers.length > 0 && (
-          <BestSellers
-            products={offers}
-            headingId="ofertas-exclusivas"
-            title="Ofertas exclusivas"
-            description="Productos con precios especiales por tiempo limitado: aprovecha descuentos y packs promocionales."
-            ctaHref="/categoria/ofertas"
-            ctaLabel="Ver ofertas"
-            highlightBadges={offerHighlightBadges}
-            showBestSellerHighlight={false}
-            layout="carousel"
-            maxVisible={6}
-          />
+          <div className="relative overflow-hidden rounded-[3rem] border border-night-border/60 bg-gradient-to-br from-[#150015] via-[#2f0124] to-[#420234] px-6 py-12 sm:px-10 lg:px-16">
+            <div className="pointer-events-none absolute inset-y-0 left-[-12%] hidden w-[40%] lg:block" aria-hidden>
+              <Image
+                src="/landing/consolador-fondo-negro-y-balnco-contraste.webp"
+                alt=""
+                fill
+                className="object-cover object-center opacity-70 mix-blend-screen"
+                sizes="(min-width: 1024px) 36vw, 60vw"
+              />
+            </div>
+            <div className="pointer-events-none absolute -right-24 bottom-[-6rem] hidden h-72 w-72 rounded-full bg-fuchsia-500/30 blur-3xl sm:block" aria-hidden />
+            <div className="relative z-10">
+              <BestSellers
+                products={offers}
+                headingId="ofertas-exclusivas"
+                title="Ofertas exclusivas"
+                description="Productos con precios especiales por tiempo limitado: aprovecha descuentos y packs promocionales."
+                ctaHref="/categoria/ofertas"
+                ctaLabel="Ver ofertas"
+                highlightBadges={offerHighlightBadges}
+                showBestSellerHighlight={false}
+                layout="carousel"
+                maxVisible={6}
+              />
+            </div>
+          </div>
         )}
+
         {normalizedOtherCategories.length > 0 && (
-          <section className="space-y-4">
-            <h2 id="buscas-algo-mas-especifico" className="text-xl font-semibold text-white">
-              ¿Buscas algo más específico?
-            </h2>
-            <p className="text-sm text-night-muted">
-              Recorre las categorías sensibles y temáticas creadas para diferentes niveles de experiencia.
-            </p>
-            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3">
-              {normalizedOtherCategories.map(category => (
-                <CategoryCard key={category.slug} category={category} />
-              ))}
+          <section className="relative overflow-hidden rounded-[3rem] border border-night-border/60 bg-gradient-to-br from-[#08000c] via-[#1f0020] to-[#2f0230] px-6 py-12 sm:px-10 lg:px-16">
+            <div className="pointer-events-none absolute inset-y-0 right-[-10%] hidden w-[40%] lg:block" aria-hidden>
+              <Image
+                src="/landing/vibrador-fondo-negro.webp"
+                alt=""
+                fill
+                className="object-cover object-center opacity-65 mix-blend-screen"
+                sizes="(min-width: 1024px) 34vw, 60vw"
+              />
+            </div>
+            <div className="relative z-10 space-y-6">
+              <h2 id="buscas-algo-mas-especifico" className="text-xl font-semibold text-white lg:text-2xl">
+                ¿Buscas algo más específico?
+              </h2>
+              <p className="max-w-2xl text-sm text-night-muted">
+                Recorre las categorías sensibles y temáticas creadas para diferentes niveles de experiencia.
+              </p>
+              <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3">
+                {normalizedOtherCategories.map(category => (
+                  <CategoryCard key={category.slug} category={category} />
+                ))}
+              </div>
             </div>
           </section>
         )}
-
       </div>
     </>
   )

--- a/components/home/CategoryCarousel.tsx
+++ b/components/home/CategoryCarousel.tsx
@@ -53,20 +53,24 @@ export function CategoryCard({ category, href = `/categoria/${category.slug}` }:
       <MotionArticle
         whileHover={{ y: -6, boxShadow: '0 22px 38px -18px rgba(236,72,153,0.45)' }}
         transition={{ type: 'spring', stiffness: 260, damping: 20 }}
-        className="flex h-full min-h-[280px] w-full flex-col overflow-hidden rounded-2xl border border-night-border bg-night-surface/95 text-left text-night-foreground shadow-neon-sm"
+        className="flex h-full min-h-[288px] w-full flex-col overflow-hidden rounded-2xl border border-night-border bg-night-surface/95 text-left text-night-foreground shadow-neon-sm"
       >
         {category.image ? (
-          <div className="relative h-40 w-full overflow-hidden rounded-t-2xl bg-night-surface-strong/80">
+          <div className="relative aspect-[4/3] w-full overflow-hidden bg-night-surface-strong/80">
             <Image
               src={category.image}
               alt={`${category.label} — miniatura de categoría`}
               fill
               sizes="(max-width: 768px) 220px, 280px"
-              className="object-cover transition-transform duration-500 group-hover:scale-[1.05]"
+              className="object-cover object-center transition-transform duration-500 group-hover:scale-[1.05]"
+            />
+            <div
+              className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,63,164,0.28),_transparent_68%)]"
+              aria-hidden
             />
           </div>
         ) : (
-          <div className="flex h-40 w-full items-center justify-center rounded-t-2xl bg-night-surface-strong/80 text-xs font-semibold uppercase tracking-[0.08em] text-night-muted">
+          <div className="flex aspect-[4/3] w-full items-center justify-center bg-night-surface-strong/80 text-xs font-semibold uppercase tracking-[0.08em] text-night-muted">
             Explorar categoría
           </div>
         )}

--- a/components/home/InspirationalBanner.tsx
+++ b/components/home/InspirationalBanner.tsx
@@ -14,6 +14,10 @@ type InspirationalBannerProps = {
   align?: 'left' | 'right'
   ctaHref?: string
   ctaLabel?: string
+  tone?: 'night' | 'fuchsia'
+  imageAspect?: 'landscape' | 'portrait' | 'square'
+  imagePriority?: boolean
+  className?: string
 }
 
 type MotionElementProps<T extends keyof HTMLElementTagNameMap> = PropsWithChildren<
@@ -30,11 +34,34 @@ export default function InspirationalBanner({
   eyebrow,
   align = 'left',
   ctaHref,
-  ctaLabel
+  ctaLabel,
+  tone = 'night',
+  imageAspect = 'landscape',
+  imagePriority = false,
+  className
 }: InspirationalBannerProps) {
+  const aspectClassName =
+    imageAspect === 'portrait'
+      ? 'aspect-[3/4]'
+      : imageAspect === 'square'
+        ? 'aspect-square'
+        : 'aspect-[16/10]'
+
+  const sectionToneClassName =
+    tone === 'fuchsia'
+      ? 'bg-gradient-to-br from-[#2f001f]/95 via-[#3f0234]/90 to-[#160012]/95'
+      : 'bg-night-surface'
+
   const imageElement = (
-    <div className="relative h-64 overflow-hidden rounded-[2.25rem] lg:h-full">
-      <Image src={image} alt={imageAlt} fill className="object-cover" sizes="(min-width: 1024px) 50vw, 100vw" />
+    <div className={`relative h-64 overflow-hidden rounded-[2.25rem] ${aspectClassName} lg:h-full lg:aspect-auto`}>
+      <Image
+        src={image}
+        alt={imageAlt}
+        fill
+        priority={imagePriority}
+        className="object-cover object-center"
+        sizes="(min-width: 1024px) 50vw, 100vw"
+      />
       <div
         className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(236,72,153,0.25),_transparent_70%)] mix-blend-screen"
         aria-hidden
@@ -68,7 +95,7 @@ export default function InspirationalBanner({
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, amount: 0.3 }}
       transition={{ duration: 0.6, ease: 'easeOut' }}
-      className="relative overflow-hidden rounded-[2.25rem] border border-night-border bg-night-surface text-night-foreground shadow-neon"
+      className={`relative overflow-hidden rounded-[2.25rem] border border-night-border text-night-foreground shadow-neon ${sectionToneClassName} ${className ?? ''}`}
     >
       <div className="grid gap-8 lg:grid-cols-2">
         {align === 'left' ? (


### PR DESCRIPTION
## Summary
- reshape the home layout with branded gradient sections, integrated landing photography, and improved CTA styling
- update category cards to maintain consistent aspect ratio and add neon overlays that handle varied image sizes
- extend inspirational banners with tone and aspect controls to better showcase new imagery

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d34b1e00148321854dd2279cacb3e6