### PR TITLE
Adjust category cards and layout spacing

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -75,7 +75,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Tracker />
         </Suspense>
         <Header />
-        <main className="max-w-6xl mx-auto px-4 pb-24 pt-2">
+        <main className="mx-auto w-full max-w-7xl px-3 pb-24 pt-2 sm:px-4 lg:px-4">
           {children}
         </main>
         <Footer />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -78,7 +78,7 @@ export default function Page() {
   return (
     <>
       <Hero />
-      <div className="mt-8 space-y-8 sm:mt-12 sm:space-y-12 lg:space-y-20">
+      <div className="mt-8 space-y-8 sm:mt-12 sm:space-y-10 lg:space-y-16">
         <section className="relative overflow-hidden rounded-3xl border border-neutral-200 bg-gradient-to-b from-neutral-50 to-white px-4 py-10 sm:px-6 lg:px-8">
           <div className="relative z-10 space-y-10">
             <TrustBadgesStrip badges={TRUST_BADGES} />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@
 export default function Footer(){
   return (
     <footer className="mt-8 border-t border-night-border bg-night-surface backdrop-blur">
-      <div className="mx-auto flex max-w-6xl flex-col gap-2 px-4 py-6 text-sm text-night-subtle md:flex-row md:gap-6">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-2 px-3 py-6 text-sm text-night-subtle sm:px-4 md:flex-row md:gap-6">
         <div className="flex-1">© {new Date().getFullYear()} SexShop del Perú 69</div>
         <nav className="flex gap-4 text-night-foreground/80">
           <Link className="transition hover:text-white" href="/legal/privacidad">Privacidad</Link>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -76,7 +76,7 @@ export default function Header() {
         transition={{ duration: 0.35, ease: 'easeOut' }}
         className="sticky top-0 z-40 border-b border-fuchsia-700/50 bg-neutral-950/70 backdrop-blur-xl supports-[backdrop-filter]:bg-neutral-950/60"
       >
-        <header className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 text-neutral-100">
+        <header className="mx-auto flex h-14 w-full max-w-7xl items-center justify-between px-3 text-neutral-100 sm:px-4">
           <Link
             href="/"
             className="flex items-center gap-2 rounded-full px-3 py-1 text-sm font-semibold tracking-tight text-fuchsia-100 transition hover:bg-fuchsia-500/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-400/60 md:text-base"

--- a/components/home/CategoryCarousel.tsx
+++ b/components/home/CategoryCarousel.tsx
@@ -45,50 +45,38 @@ const MotionArticle = motion.article as ComponentType<MotionElementProps<'articl
 export type CategoryCardProps = {
   category: CategoryItem & { description: string; subtitle: string }
   href?: string
-  variant?: 'dark' | 'white'
 }
 
 export function CategoryCard({
   category,
-  href = `/categoria/${category.slug}`,
-  variant = 'dark'
+  href = `/categoria/${category.slug}`
 }: CategoryCardProps) {
-  const cardVariantClassName =
-    variant === 'white'
-      ? 'border border-neutral-200 bg-white text-neutral-900 shadow'
-      : 'border border-night-border bg-night-surface/95 text-night-foreground shadow-neon-sm'
-  const titleColorClassName = variant === 'white' ? 'text-neutral-900' : 'text-white'
-
   return (
     <Link href={href} className="group block h-full">
       <MotionArticle
-        whileHover={{ y: -6, boxShadow: '0 22px 38px -18px rgba(236,72,153,0.45)' }}
+        whileHover={{ y: -6, boxShadow: '0 22px 38px -18px rgba(236,72,153,0.25)' }}
         transition={{ type: 'spring', stiffness: 260, damping: 20 }}
-        className={`flex h-full min-h-[280px] w-full flex-col overflow-hidden rounded-2xl text-left ${cardVariantClassName}`}
+        className="flex h-full min-h-[280px] w-full flex-col overflow-hidden rounded-xl border border-neutral-200 bg-white text-left shadow-sm transition"
       >
         {category.image ? (
-          <div className="relative aspect-[3/4] w-full overflow-hidden bg-night-surface-strong/80">
+          <div className="relative aspect-[3/4] w-full overflow-hidden rounded-t-xl bg-neutral-100">
             <Image
               src={category.image}
               alt={`${category.label} — miniatura de categoría`}
               fill
               sizes="(max-width: 768px) 240px, 260px"
-              className="object-cover object-center transition-transform duration-500 group-hover:scale-[1.05]"
-            />
-            <div
-              className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,63,164,0.28),_transparent_68%)]"
-              aria-hidden
+              className="object-cover object-center transition-transform duration-500 md:group-hover:scale-105"
             />
           </div>
         ) : (
-          <div className="flex aspect-[3/4] w-full items-center justify-center bg-night-surface-strong/80 text-xs font-semibold uppercase tracking-[0.08em] text-night-muted">
+          <div className="flex aspect-[3/4] w-full items-center justify-center rounded-t-xl bg-neutral-100 text-xs font-semibold uppercase tracking-[0.08em] text-neutral-500">
             Explorar categoría
           </div>
         )}
-        <div className="flex flex-1 flex-col gap-1 px-5 pb-6 pt-4">
-          <h3 className={`text-lg font-extrabold uppercase ${titleColorClassName}`}>{category.label}</h3>
-          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-neutral-500 truncate">{category.subtitle}</p>
-          <p className="text-xs font-semibold uppercase text-neutral-500 truncate">{category.description}</p>
+        <div className="flex flex-1 flex-col gap-1 px-4 pb-6 pt-4">
+          <h3 className="text-lg font-extrabold uppercase text-fuchsia-600">{category.label}</h3>
+          <p className="truncate text-xs font-semibold uppercase tracking-[0.08em] text-neutral-500">{category.subtitle}</p>
+          <p className="truncate text-xs font-semibold uppercase text-neutral-400">{category.description}</p>
         </div>
       </MotionArticle>
     </Link>


### PR DESCRIPTION
## Summary
- refresh category cards with white surface, fuchsia accents, and refined hover media behaviour
- enlarge global wrappers to max-w-7xl with tighter horizontal padding for desktop breathing room
- align home spacing to use tighter gaps on mobile while keeping ample separation on large screens

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d3eaf4b3708321b1c7788f057d1a81