### PR TITLE
Make category filters open in a dropdown

### DIFF
--- a/app/categoria/[slug]/category-filters-client.tsx
+++ b/app/categoria/[slug]/category-filters-client.tsx
@@ -216,7 +216,7 @@ export default function CategoryFiltersClient() {
     <CategoryFiltersProvider value={contextValue}>
       <div className="mt-6 space-y-6">
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-1 items-center gap-3">
+          <div className="flex flex-1 flex-col gap-3 sm:flex-row sm:items-center sm:gap-3">
             <input
               value={filters.query}
               onChange={(event) => onQueryChange(event.target.value)}
@@ -224,41 +224,43 @@ export default function CategoryFiltersClient() {
               aria-label="Buscar"
               className="flex-1 rounded-xl border border-neutral-200 px-4 py-2 text-sm shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
             />
-            <button
-              type="button"
-              className="inline-flex items-center gap-2 rounded-xl border border-neutral-200 px-3 py-2 text-sm font-medium text-neutral-700 shadow-sm transition hover:border-brand-primary/60 hover:text-brand-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary md:hidden"
-              onClick={() => setIsSheetOpen(true)}
-            >
-              Filtros
-            </button>
+            <div className="relative">
+              <button
+                type="button"
+                aria-expanded={isSheetOpen}
+                aria-haspopup="dialog"
+                className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-neutral-200 px-3 py-2 text-sm font-medium text-neutral-700 shadow-sm transition hover:border-brand-primary/60 hover:text-brand-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary sm:w-auto"
+                onClick={() => setIsSheetOpen((prev) => !prev)}
+              >
+                Filtros
+              </button>
+              <FilterSheet
+                open={isSheetOpen}
+                onOpenChange={setIsSheetOpen}
+                filters={filters}
+                options={options}
+                onToggleBrand={(value) => toggleValue('brands', value)}
+                onToggleMaterial={(value) => toggleValue('materials', value)}
+                onSelectLongitud={(value) => setDimension('longitud', value)}
+                onSelectDiametro={(value) => setDimension('diametro', value)}
+                onReset={resetFilters}
+              />
+            </div>
           </div>
           <p className="text-sm text-neutral-500">{filteredProducts.length} productos</p>
         </div>
-        <div className="grid gap-6 md:grid-cols-[280px,1fr] md:items-start">
-          <FilterSheet
-            open={isSheetOpen}
-            onOpenChange={setIsSheetOpen}
-            filters={filters}
-            options={options}
-            onToggleBrand={(value) => toggleValue('brands', value)}
-            onToggleMaterial={(value) => toggleValue('materials', value)}
-            onSelectLongitud={(value) => setDimension('longitud', value)}
-            onSelectDiametro={(value) => setDimension('diametro', value)}
-            onReset={resetFilters}
-          />
-          <div className="space-y-4">
-            {filteredProducts.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-neutral-200 bg-white p-8 text-center text-sm text-neutral-500">
-                No se encontraron productos con los filtros seleccionados.
-              </div>
-            ) : (
-              <div className="grid gap-y-6 gap-x-4 grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6">
-                {filteredProducts.map((product) => (
-                  <ProductCard key={product.slug} p={product} />
-                ))}
-              </div>
-            )}
-          </div>
+        <div className="space-y-4">
+          {filteredProducts.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-neutral-200 bg-white p-8 text-center text-sm text-neutral-500">
+              No se encontraron productos con los filtros seleccionados.
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-x-4 gap-y-6 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-6">
+              {filteredProducts.map((product) => (
+                <ProductCard key={product.slug} p={product} />
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </CategoryFiltersProvider>

--- a/components/category/FilterSheet.tsx
+++ b/components/category/FilterSheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Fragment } from 'react'
+import { Fragment, useEffect, useRef } from 'react'
 import { Dialog, Transition } from '@headlessui/react'
 import type { CategoryFilterState } from './filters-context'
 
@@ -170,19 +170,62 @@ export default function FilterSheet({
   onSelectDiametro,
   onReset
 }: FilterSheetProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const panel = panelRef.current
+      if (!panel) return
+      if (panel.contains(event.target as Node)) return
+      onOpenChange(false)
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onOpenChange(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open, onOpenChange])
+
   return (
     <>
-      <aside className="hidden h-full w-full max-w-xs rounded-2xl border border-neutral-200 bg-white shadow-sm md:block">
-        <FilterContent
-          filters={filters}
-          options={options}
-          onToggleBrand={onToggleBrand}
-          onToggleMaterial={onToggleMaterial}
-          onSelectLongitud={onSelectLongitud}
-          onSelectDiametro={onSelectDiametro}
-          onReset={onReset}
-        />
-      </aside>
+      <div className="pointer-events-none absolute right-0 top-full z-50 mt-3 hidden w-[min(90vw,360px)] md:block">
+        <Transition
+          show={open}
+          as={Fragment}
+          enter="transition ease-out duration-200"
+          enterFrom="opacity-0 translate-y-1"
+          enterTo="opacity-100 translate-y-0"
+          leave="transition ease-in duration-150"
+          leaveFrom="opacity-100 translate-y-0"
+          leaveTo="opacity-0 translate-y-1"
+        >
+          <div
+            ref={panelRef}
+            className="pointer-events-auto max-h-[75vh] overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-xl"
+          >
+            <FilterContent
+              filters={filters}
+              options={options}
+              onToggleBrand={onToggleBrand}
+              onToggleMaterial={onToggleMaterial}
+              onSelectLongitud={onSelectLongitud}
+              onSelectDiametro={onSelectDiametro}
+              onReset={onReset}
+            />
+          </div>
+        </Transition>
+      </div>
       <Transition.Root show={open} as={Fragment}>
         <Dialog as="div" className="relative z-50 md:hidden" onClose={onOpenChange}>
           <Transition.Child


### PR DESCRIPTION
## Summary
- replace the desktop sidebar filters with a shared dropdown trigger so the panel no longer occupies layout space
- reuse the FilterSheet component for the dropdown and keep the mobile sheet while adding outside click/escape handling

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d40131918c8321b8566074f11b814a