### PR TITLE
Add collection catalog support and listing page

### DIFF
--- a/app/coleccion/[slug]/page.tsx
+++ b/app/coleccion/[slug]/page.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import CollectionFiltersClient from './collection-filters-client'
+import { allCollections, findCollection, productsForCollection } from '@/lib/collections'
+import {
+  collectCatalogOptions,
+  filterCatalogProducts,
+  parseCatalogSearchParams,
+  type CatalogFilters
+} from '@/lib/catalog-filters'
+
+export const runtime = 'nodejs'
+
+function toURLSearchParams(searchParams: Record<string, string | string[] | undefined>): URLSearchParams {
+  const params = new URLSearchParams()
+  Object.entries(searchParams).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach(entry => {
+        if (entry !== undefined) params.append(key, entry)
+      })
+      return
+    }
+    if (value !== undefined) params.append(key, value)
+  })
+  return params
+}
+
+export function generateStaticParams() {
+  return allCollections().map(collection => ({ slug: collection.slug }))
+}
+
+export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
+  const collection = findCollection(params.slug)
+  if (!collection) return {}
+
+  const title = collection.seo?.title ?? `${collection.name} — SexShop del Perú 69`
+  const description = collection.seo?.description ?? collection.description ?? undefined
+  const canonical = `/coleccion/${collection.slug}`
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      type: 'website',
+      title,
+      description,
+      url: canonical,
+      siteName: 'SexShop del Perú 69'
+    }
+  }
+}
+
+export default function CollectionPage({
+  params,
+  searchParams
+}: {
+  params: { slug: string }
+  searchParams: Record<string, string | string[] | undefined>
+}) {
+  const collection = findCollection(params.slug)
+  if (!collection) return notFound()
+
+  const urlSearchParams = toURLSearchParams(searchParams)
+  const initialFilters: CatalogFilters = parseCatalogSearchParams(urlSearchParams)
+  const allMatchingProducts = productsForCollection(collection)
+  const filteredProducts = filterCatalogProducts(allMatchingProducts, initialFilters)
+  const options = collectCatalogOptions(allMatchingProducts)
+
+  return (
+    <div>
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold text-neutral-900">{collection.name}</h1>
+        {collection.headline && <p className="text-sm font-medium text-brand-primary">{collection.headline}</p>}
+        {collection.description && <p className="max-w-2xl text-sm text-neutral-600">{collection.description}</p>}
+        <p className="text-xs text-neutral-500">{filteredProducts.length} productos disponibles</p>
+      </div>
+      <CollectionFiltersClient
+        slug={collection.slug}
+        products={allMatchingProducts}
+        options={options}
+        initialFilters={initialFilters}
+      />
+    </div>
+  )
+}

--- a/components/category/filters-context.tsx
+++ b/components/category/filters-context.tsx
@@ -1,14 +1,9 @@
 'use client'
 
 import { createContext, useContext, type ReactNode } from 'react'
+import type { CatalogFilters } from '@/lib/catalog-filters'
 
-export type CategoryFilterState = {
-  query: string
-  brands: string[]
-  materials: string[]
-  longitud: string | null
-  diametro: string | null
-}
+export type CategoryFilterState = CatalogFilters
 
 export type CategoryFiltersContextValue = {
   filters: CategoryFilterState

--- a/data/collections.json
+++ b/data/collections.json
@@ -1,0 +1,50 @@
+[
+  {
+    "slug": "juegos-en-pareja",
+    "name": "Juegos en pareja",
+    "headline": "Vibraciones para disfrutar juntos",
+    "description": "Selección de juguetes pensados para sincronizar el placer y explorar nuevas sensaciones en pareja.",
+    "rule": {
+      "anyOf": {
+        "categories": ["pareja", "vibradores"],
+        "tags": ["uso:Estimulación vibratoria", "feature:Estimulación dual"]
+      }
+    },
+    "seo": {
+      "title": "Colección de juguetes para parejas — SexShop del Perú 69",
+      "description": "Encuentra vibradores y accesorios diseñados para parejas que buscan compartir momentos intensos con total confianza."
+    }
+  },
+  {
+    "slug": "exploracion-anal-suave",
+    "name": "Exploración anal suave",
+    "headline": "Comodidad y control en cada paso",
+    "description": "Productos con formas amigables, texturas progresivas y materiales suaves para descubrir el placer anal a tu ritmo.",
+    "rule": {
+      "anyOf": {
+        "categories": ["consoladores"],
+        "tags": ["uso:Estimulación anal"]
+      }
+    },
+    "seo": {
+      "title": "Colección para exploración anal suave — SexShop del Perú 69",
+      "description": "Descubre plugs y consoladores que priorizan la comodidad y el cuidado para tu primera o próxima experiencia anal."
+    }
+  },
+  {
+    "slug": "aromas-y-feromonas",
+    "name": "Aromas y feromonas",
+    "headline": "Activa los sentidos",
+    "description": "Perfumes y aceites con feromonas para despertar la atracción y crear momentos cargados de sensualidad.",
+    "rule": {
+      "anyOf": {
+        "categories": ["feromonas", "bienestar"],
+        "tags": ["feature:Feromonas"]
+      }
+    },
+    "seo": {
+      "title": "Colección de aromas y feromonas — SexShop del Perú 69",
+      "description": "Perfumes afrodisíacos y mezclas con feromonas listas para acompañarte con discreción y un toque irresistible."
+    }
+  }
+]

--- a/lib/catalog-filters.ts
+++ b/lib/catalog-filters.ts
@@ -1,0 +1,135 @@
+import type { Product, ProductAttributeValue } from './products'
+
+export type CatalogFilters = {
+  query: string
+  brands: string[]
+  materials: string[]
+  longitud: string | null
+  diametro: string | null
+}
+
+export type CatalogFilterOptions = {
+  brands: string[]
+  materials: string[]
+  longitudes: string[]
+  diametros: string[]
+}
+
+function isMeaningfulAttribute(value: ProductAttributeValue): value is string {
+  if (value === null || value === undefined) return false
+  if (typeof value === 'boolean') return true
+  if (typeof value === 'number') return true
+  if (typeof value !== 'string') return false
+  const normalized = value.trim()
+  if (!normalized) return false
+  return !normalized.toLowerCase().includes('valor por defecto')
+}
+
+export function normalizeCatalogText(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+}
+
+export function parseCatalogSearchParams(searchParams: URLSearchParams): CatalogFilters {
+  const query = searchParams.get('q') ?? ''
+  const brands = searchParams.getAll('brand')
+  const materials = searchParams.getAll('material')
+  const longitud = searchParams.get('longitud')
+  const diametro = searchParams.get('diametro')
+  return {
+    query,
+    brands,
+    materials,
+    longitud: longitud ?? null,
+    diametro: diametro ?? null
+  }
+}
+
+export function buildCatalogSearchParams(filters: CatalogFilters): URLSearchParams {
+  const params = new URLSearchParams()
+  if (filters.query) params.set('q', filters.query)
+  filters.brands.forEach(brand => {
+    if (brand) params.append('brand', brand)
+  })
+  filters.materials.forEach(material => {
+    if (material) params.append('material', material)
+  })
+  if (filters.longitud) params.set('longitud', filters.longitud)
+  if (filters.diametro) params.set('diametro', filters.diametro)
+  return params
+}
+
+export function filterCatalogProducts(products: Product[], filters: CatalogFilters): Product[] {
+  const normalizedQuery = normalizeCatalogText(filters.query).trim()
+
+  return products.filter(product => {
+    if (normalizedQuery) {
+      const haystack = [
+        product.name,
+        product.brand,
+        ...Object.values(product.attributes ?? {})
+      ]
+        .filter((value): value is string => typeof value === 'string')
+        .map(value => normalizeCatalogText(value))
+        .join(' ')
+      if (!haystack.includes(normalizedQuery)) return false
+    }
+
+    if (filters.brands.length) {
+      const brand = product.brand
+      if (!brand) return false
+      if (!filters.brands.some(value => normalizeCatalogText(value) === normalizeCatalogText(brand))) {
+        return false
+      }
+    }
+
+    if (filters.materials.length) {
+      const material = product.attributes?.material
+      if (!material || typeof material !== 'string') return false
+      if (!filters.materials.some(value => normalizeCatalogText(value) === normalizeCatalogText(material))) {
+        return false
+      }
+    }
+
+    if (filters.longitud) {
+      const longitud = product.attributes?.longitud
+      if (!longitud || typeof longitud !== 'string') return false
+      if (normalizeCatalogText(longitud) !== normalizeCatalogText(filters.longitud)) return false
+    }
+
+    if (filters.diametro) {
+      const diametro = product.attributes?.diametro
+      if (!diametro || typeof diametro !== 'string') return false
+      if (normalizeCatalogText(diametro) !== normalizeCatalogText(filters.diametro)) return false
+    }
+
+    return true
+  })
+}
+
+export function collectCatalogOptions(products: Product[]): CatalogFilterOptions {
+  const brandSet = new Set<string>()
+  const materialSet = new Set<string>()
+  const longitudSet = new Set<string>()
+  const diametroSet = new Set<string>()
+
+  products.forEach(product => {
+    if (product.brand) brandSet.add(product.brand)
+
+    const { material, longitud, diametro } = product.attributes ?? {}
+    if (isMeaningfulAttribute(material) && typeof material === 'string') materialSet.add(material)
+    if (isMeaningfulAttribute(longitud) && typeof longitud === 'string') longitudSet.add(longitud)
+    if (isMeaningfulAttribute(diametro) && typeof diametro === 'string') diametroSet.add(diametro)
+  })
+
+  const sortFn = (a: string, b: string) => a.localeCompare(b, 'es')
+
+  return {
+    brands: Array.from(brandSet).sort(sortFn),
+    materials: Array.from(materialSet).sort(sortFn),
+    longitudes: Array.from(longitudSet).sort(sortFn),
+    diametros: Array.from(diametroSet).sort(sortFn)
+  }
+}

--- a/lib/collections.ts
+++ b/lib/collections.ts
@@ -1,0 +1,98 @@
+import collectionsData from '@/data/collections.json'
+import type { Product } from './products'
+import { allProducts } from './products'
+import { enrichTags, parseTagStrings, type Tag } from './tagging'
+
+type RawCollection = (typeof collectionsData)[number]
+
+type RawCollectionRule = RawCollection['rule']
+
+type RawAnyOf = NonNullable<RawCollectionRule>['anyOf']
+
+export type CollectionRule = {
+  anyOf?: {
+    tags: Tag[]
+    categories: string[]
+  }
+}
+
+export type Collection = Omit<RawCollection, 'rule'> & {
+  rule: CollectionRule
+}
+
+function normalizeCategorySlug(slug: string | null | undefined): string | null {
+  if (!slug) return null
+  const trimmed = slug.trim().toLowerCase()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeAnyOf(anyOf: RawAnyOf | undefined): CollectionRule['anyOf'] {
+  if (!anyOf) return undefined
+  const tags = parseTagStrings(anyOf.tags)
+  const categories = (anyOf.categories ?? [])
+    .map(category => normalizeCategorySlug(category))
+    .filter((category): category is string => Boolean(category))
+  if (tags.length === 0 && categories.length === 0) return undefined
+  return { tags, categories }
+}
+
+function normalizeCollection(collection: RawCollection): Collection {
+  const anyOf = normalizeAnyOf(collection.rule?.anyOf)
+  return {
+    ...collection,
+    rule: { ...(anyOf ? { anyOf } : {}) }
+  }
+}
+
+const collections: Collection[] = (collectionsData as RawCollection[]).map(normalizeCollection)
+
+function getProductTags(product: Product): Tag[] {
+  if (product.tags && product.tags.length > 0) return product.tags
+  return enrichTags({
+    category: product.category,
+    subCategory: product.subCategory ?? null,
+    name: product.name,
+    shortDescription: product.shortDescription ?? null,
+    descriptionHtml: product.descriptionHtml ?? null,
+    descriptionText: product.descriptionText ?? null,
+    tags: []
+  })
+}
+
+function hasMatchingTag(productTags: Tag[], ruleTags: Tag[]): boolean {
+  if (ruleTags.length === 0) return false
+  const productTagKeys = new Set(productTags.map(tag => `${tag.type}:${tag.value.toLowerCase()}`))
+  return ruleTags.some(tag => productTagKeys.has(`${tag.type}:${tag.value.toLowerCase()}`))
+}
+
+function hasMatchingCategory(product: Product, categories: string[]): boolean {
+  if (categories.length === 0) return false
+  const productCategories = [product.category, product.subCategory]
+    .map(value => normalizeCategorySlug(value))
+    .filter((value): value is string => Boolean(value))
+  if (productCategories.length === 0) return false
+  return categories.some(category => productCategories.includes(category))
+}
+
+export function matchCollection(product: Product, rule: CollectionRule): boolean {
+  const anyOf = rule.anyOf
+  if (!anyOf) return true
+  const tagsMatch = hasMatchingTag(getProductTags(product), anyOf.tags)
+  if (tagsMatch) return true
+  const categoryMatch = hasMatchingCategory(product, anyOf.categories)
+  return categoryMatch
+}
+
+export function allCollections(): Collection[] {
+  return collections
+}
+
+export function findCollection(slug: string): Collection | undefined {
+  const normalized = normalizeCategorySlug(slug)
+  if (!normalized) return undefined
+  return collections.find(collection => collection.slug === normalized)
+}
+
+export function productsForCollection(collection: Collection): Product[] {
+  return allProducts().filter(product => matchCollection(product, collection.rule))
+}


### PR DESCRIPTION
## Summary
- add collection definitions and helper utilities to match products against collection rules
- share catalog filter parsing between category and collection listing experiences
- implement the /coleccion/[slug] page that loads collections, filters products, and renders the listing UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daf9906eec832192ca65b6ff68cb34