### PR TITLE
Add persona mega menu configuration and integrate into header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,26 +3,15 @@
 import Link from 'next/link'
 import {
   ComponentType,
-  FocusEvent,
   PropsWithChildren,
   useEffect,
-  useRef,
   useState,
 } from 'react'
 import { AnimatePresence, motion, type HTMLMotionProps } from 'framer-motion'
-import {
-  ChevronDown,
-  ChevronRight,
-  Menu,
-  MessageCircle,
-  Search,
-  ShoppingBag,
-  Sparkles,
-  X,
-} from 'lucide-react'
+import { Menu, MessageCircle, Search, ShoppingBag, X } from 'lucide-react'
 
 import SearchOverlay from './header/SearchOverlay'
-import categoriesData from '@/data/categories.json'
+import MegaMenu from './nav/MegaMenu'
 import { openChatAssistant } from '@/lib/chat-assistant'
 
 const MotionWrapper: any = motion.div
@@ -32,31 +21,16 @@ const MotionMobileOverlay = motion.div as ComponentType<
 const MotionButton: any = motion.button
 const MotionAside: any = motion.aside
 
-type Category = {
-  slug: string
-  label: string
-  children?: {
-    slug: string
-    label: string
-  }[]
-}
-
 const primaryLinks = [
   { href: '/novedades', label: 'Novedades' },
   { href: '/ofertas', label: 'Ofertas' },
   { href: '/blog', label: 'Blog/Guías' },
 ]
 
-const categoryIcons = [Sparkles, ShoppingBag, MessageCircle]
-
-const categories = categoriesData as Category[]
-
 export default function Header() {
   const [menuOpen, setMenuOpen] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)
   const [isScrolled, setIsScrolled] = useState(false)
-  const [desktopCategoriesOpen, setDesktopCategoriesOpen] = useState(false)
-  const desktopCloseTimeout = useRef<NodeJS.Timeout | null>(null)
 
   useEffect(() => {
     const handleScroll = () => {
@@ -71,14 +45,6 @@ export default function Header() {
     }
   }, [])
 
-  useEffect(() => {
-    return () => {
-      if (desktopCloseTimeout.current) {
-        clearTimeout(desktopCloseTimeout.current)
-      }
-    }
-  }, [])
-
   const toggleMenu = () => setMenuOpen((prev) => !prev)
   const openSearch = () => {
     setSearchOpen(true)
@@ -87,50 +53,6 @@ export default function Header() {
 
   const openChat = () => {
     openChatAssistant()
-  }
-
-  const desktopCategories = categories.slice(0, 6)
-  const desktopMenuId = 'desktop-categories-menu'
-
-  const handleMouseEnter = () => {
-    if (desktopCloseTimeout.current) {
-      clearTimeout(desktopCloseTimeout.current)
-      desktopCloseTimeout.current = null
-    }
-    setDesktopCategoriesOpen(true)
-  }
-
-  const handleMouseLeave = () => {
-    if (desktopCloseTimeout.current) {
-      clearTimeout(desktopCloseTimeout.current)
-      desktopCloseTimeout.current = null
-    }
-    desktopCloseTimeout.current = setTimeout(() => {
-      setDesktopCategoriesOpen(false)
-      desktopCloseTimeout.current = null
-    }, 300)
-  }
-
-  const closeDesktopCategories = () => {
-    if (desktopCloseTimeout.current) {
-      clearTimeout(desktopCloseTimeout.current)
-      desktopCloseTimeout.current = null
-    }
-    setDesktopCategoriesOpen(false)
-  }
-
-  const handleDesktopBlur = (event: FocusEvent<HTMLDivElement>) => {
-    if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
-      closeDesktopCategories()
-    }
-  }
-
-  const toggleDesktopCategories = () => {
-    if (desktopCloseTimeout.current) {
-      clearTimeout(desktopCloseTimeout.current)
-      desktopCloseTimeout.current = null
-    }
-    setDesktopCategoriesOpen((prev) => !prev)
   }
 
   return (
@@ -162,80 +84,7 @@ export default function Header() {
           </Link>
 
           <nav className="hidden items-center gap-2 text-sm font-medium md:flex">
-            <div
-              className="relative"
-              onMouseEnter={handleMouseEnter}
-              onMouseLeave={handleMouseLeave}
-              onFocus={handleMouseEnter}
-              onBlur={handleDesktopBlur}
-              onKeyDown={(event) => {
-                if (event.key === 'Escape') {
-                  closeDesktopCategories()
-                }
-              }}
-            >
-              <button
-                type="button"
-                aria-haspopup="true"
-                aria-expanded={desktopCategoriesOpen}
-                aria-controls={desktopMenuId}
-                onClick={toggleDesktopCategories}
-                className="inline-flex items-center gap-1 rounded-full px-3 py-2 text-brand-primary/90 transition hover:bg-brand-primary/15 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60"
-              >
-                <Sparkles className="h-4 w-4" aria-hidden />
-                Categorías
-                <ChevronDown
-                  className={`h-4 w-4 transition ${desktopCategoriesOpen ? 'rotate-180' : ''}`}
-                  aria-hidden
-                />
-              </button>
-
-              <div
-                id={desktopMenuId}
-                className={`absolute left-0 top-full z-10 min-w-[18rem] rounded-2xl border border-brand-primary/30 bg-neutral-950/95 p-4 text-sm text-neutral-100 shadow-2xl ring-1 ring-white/5 transition duration-150 ${
-                  desktopCategoriesOpen
-                    ? 'pointer-events-auto block translate-y-2 opacity-100'
-                    : 'pointer-events-none hidden -translate-y-1 opacity-0'
-                }`}
-              >
-                <ul className="grid grid-cols-1 gap-3">
-                  {desktopCategories.map((category, index) => {
-                    const Icon = categoryIcons[index % categoryIcons.length]
-                    const previewChildren = category.children
-                      ?.slice(0, 2)
-                      .map((child) => child.label)
-                    return (
-                      <li key={category.slug}>
-                        <Link
-                          href={`/categoria/${category.slug}`}
-                          className="flex items-start gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 transition hover:border-brand-primary/40 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60"
-                        >
-                          <span className="mt-1 inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-brand-primary/20 text-brand-primary">
-                            <Icon className="h-4 w-4" aria-hidden />
-                          </span>
-                          <span className="flex flex-col">
-                            <span className="font-semibold">{category.label}</span>
-                            <span className="text-xs text-neutral-300">
-                              {previewChildren?.length
-                                ? previewChildren.join(' · ')
-                                : 'Explora las subcategorías'}
-                            </span>
-                          </span>
-                        </Link>
-                      </li>
-                    )
-                  })}
-                </ul>
-                <Link
-                  href="/categorias"
-                  className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-brand-primary/80 transition hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60"
-                >
-                  Ver todas las categorías
-                  <ChevronRight className="h-4 w-4" aria-hidden />
-                </Link>
-              </div>
-            </div>
-
+            <MegaMenu />
             {primaryLinks.map((link) => (
               <Link
                 key={link.href}
@@ -326,45 +175,7 @@ export default function Header() {
                 <div className="relative flex-1 overflow-hidden">
                   <div className="h-full overflow-y-auto px-4 pb-10">
                     <nav className="space-y-6">
-                      <div>
-                        <p className="text-xs font-semibold uppercase tracking-wide text-brand-primary/80">Categorías</p>
-                        <ul className="mt-3 space-y-4">
-                          {categories.map((category, index) => {
-                            const Icon = categoryIcons[index % categoryIcons.length]
-                            return (
-                              <li key={category.slug}>
-                                <div className="rounded-xl border border-white/5 bg-white/5 px-3 py-3 text-sm transition hover:border-brand-primary/40 hover:bg-white/10 focus-within:border-brand-primary/40 focus-within:bg-white/10">
-                                  <Link
-                                    href={`/categoria/${category.slug}`}
-                                    onClick={() => setMenuOpen(false)}
-                                    className="flex items-center gap-2 font-semibold text-neutral-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
-                                  >
-                                    <Icon className="h-4 w-4 text-brand-primary" aria-hidden />
-                                    {category.label}
-                                  </Link>
-                                  {category.children && category.children.length > 0 && (
-                                    <ul className="mt-2 space-y-1 text-xs text-neutral-200">
-                                      {category.children.map((child) => (
-                                        <li key={child.slug}>
-                                          <Link
-                                            href={`/categoria/${child.slug}`}
-                                            onClick={() => setMenuOpen(false)}
-                                            className="flex items-center justify-between rounded-md px-2 py-1 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-primary/70"
-                                          >
-                                            <span>{child.label}</span>
-                                            <ChevronRight className="h-3.5 w-3.5 text-brand-primary/70" aria-hidden />
-                                          </Link>
-                                        </li>
-                                      ))}
-                                    </ul>
-                                  )}
-                                </div>
-                              </li>
-                            )
-                          })}
-                        </ul>
-                      </div>
-
+                      <MegaMenu variant="mobile" onNavigate={() => setMenuOpen(false)} />
                       <div className="space-y-2">
                         <p className="text-xs font-semibold uppercase tracking-wide text-brand-primary/80">Descubre más</p>
                         {primaryLinks.map((link) => (

--- a/components/nav/MegaMenu.tsx
+++ b/components/nav/MegaMenu.tsx
@@ -1,0 +1,450 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronDown, ChevronRight, Sparkles } from 'lucide-react'
+
+import { megaMenuConfig } from '@/data/mega-menu.config'
+import type { MegaMenuLink, MegaMenuTab } from '@/data/mega-menu.config'
+
+type MegaMenuProps = {
+  variant?: 'desktop' | 'mobile'
+  onNavigate?: () => void
+}
+
+type TrackContext = 'column' | 'quick-link' | 'cta'
+
+type TrackPayload = {
+  tab: MegaMenuTab
+  linkLabel: string
+  href: string
+  context: TrackContext
+  columnTitle?: string
+}
+
+function trackMegaMenuInteraction({ tab, linkLabel, href, context, columnTitle }: TrackPayload) {
+  if (typeof window === 'undefined') return
+  const gtag = (window as any).gtag
+  if (typeof gtag !== 'function') return
+
+  gtag('event', 'mega_menu_click', {
+    menu_tab: tab.id,
+    menu_tab_label: tab.label,
+    menu_link_label: linkLabel,
+    menu_link_url: href,
+    menu_link_context: context,
+    ...(columnTitle ? { menu_column: columnTitle } : {})
+  })
+}
+
+function DesktopMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
+  const tabs = megaMenuConfig.tabs
+  const hasTabs = tabs.length > 0
+  const [open, setOpen] = useState(false)
+  const [activeTabId, setActiveTabId] = useState(tabs[0]?.id ?? '')
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const menuRef = useRef<HTMLDivElement | null>(null)
+  const closeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const activeTab = useMemo(() => {
+    if (!tabs.length) return undefined
+    return tabs.find((tab) => tab.id === activeTabId) ?? tabs[0]
+  }, [tabs, activeTabId])
+
+  const clearScheduledClose = useCallback(() => {
+    if (closeTimeout.current) {
+      clearTimeout(closeTimeout.current)
+      closeTimeout.current = null
+    }
+  }, [])
+
+  const scheduleClose = useCallback(() => {
+    clearScheduledClose()
+    closeTimeout.current = setTimeout(() => {
+      setOpen(false)
+      closeTimeout.current = null
+    }, 160)
+  }, [clearScheduledClose])
+
+  const handleOpen = useCallback(() => {
+    if (!hasTabs) return
+    clearScheduledClose()
+    setOpen(true)
+  }, [clearScheduledClose, hasTabs])
+
+  const handleClose = useCallback(() => {
+    clearScheduledClose()
+    setOpen(false)
+  }, [clearScheduledClose])
+
+  useEffect(() => {
+    return () => {
+      clearScheduledClose()
+    }
+  }, [clearScheduledClose])
+
+  useEffect(() => {
+    if (!open) return
+
+    function onPointerDown(event: MouseEvent) {
+      const target = event.target as Node | null
+      if (!target) return
+      if (containerRef.current?.contains(target)) return
+      handleClose()
+    }
+
+    function onEscape(event: KeyboardEvent) {
+      if (event.key !== 'Escape') return
+      if (!open) return
+      event.preventDefault()
+      handleClose()
+      triggerRef.current?.focus()
+    }
+
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onEscape)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onEscape)
+    }
+  }, [open, handleClose])
+
+  useEffect(() => {
+    if (!open) return
+    if (typeof document === 'undefined') return
+    if (document.activeElement !== triggerRef.current) return
+
+    const focusable = menuRef.current?.querySelector<HTMLElement>('button, a')
+    focusable?.focus({ preventScroll: true })
+  }, [open, activeTab])
+
+  if (!hasTabs) {
+    return null
+  }
+
+  if (!activeTab) {
+    return null
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative hidden md:block"
+      onMouseEnter={handleOpen}
+      onMouseLeave={scheduleClose}
+      onFocusCapture={handleOpen}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          scheduleClose()
+        }
+      }}
+    >
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-controls="mega-menu-panel"
+        onClick={() => {
+          if (open) {
+            handleClose()
+          } else {
+            handleOpen()
+          }
+        }}
+        className={`inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60 ${
+          open
+            ? 'bg-brand-primary/20 text-white'
+            : 'text-brand-primary/90 hover:bg-brand-primary/15 hover:text-white'
+        }`}
+      >
+        <Sparkles className="h-4 w-4" aria-hidden />
+        Categorías
+        <ChevronDown
+          className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`}
+          aria-hidden
+        />
+      </button>
+
+      <div
+        ref={menuRef}
+        id="mega-menu-panel"
+        aria-hidden={!open}
+        className={`absolute left-0 top-full z-30 w-[min(48rem,calc(100vw-2rem))] pt-3 transition duration-150 ease-out ${
+          open ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
+        }`}
+        style={{ transform: open ? 'translateY(0.5rem)' : 'translateY(0.25rem)' }}
+      >
+        <div className="rounded-3xl border border-brand-primary/30 bg-neutral-950/95 p-6 text-sm text-neutral-100 shadow-2xl ring-1 ring-white/5">
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-1">
+                <span className="text-xs font-semibold uppercase tracking-[0.28em] text-brand-primary/80">
+                  {activeTab.tagline}
+                </span>
+                <p className="text-base font-semibold text-neutral-50">{activeTab.label}</p>
+                <p className="text-sm text-neutral-300">{activeTab.description}</p>
+              </div>
+
+              <div role="tablist" aria-label="Personas" className="flex flex-wrap gap-2">
+                {tabs.map((tab) => {
+                  const isActive = tab.id === activeTab.id
+                  return (
+                    <button
+                      key={tab.id}
+                      type="button"
+                      role="tab"
+                      id={`mega-tab-${tab.id}`}
+                      aria-selected={isActive}
+                      aria-controls={`mega-panel-${tab.id}`}
+                      className={`rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60 ${
+                        isActive
+                          ? 'border-brand-primary/70 bg-brand-primary/20 text-white'
+                          : 'border-transparent bg-white/5 text-brand-primary/70 hover:border-brand-primary/40 hover:bg-white/10 hover:text-white'
+                      }`}
+                      onMouseEnter={() => setActiveTabId(tab.id)}
+                      onFocus={() => setActiveTabId(tab.id)}
+                      onClick={() => setActiveTabId(tab.id)}
+                    >
+                      {tab.label}
+                    </button>
+                  )
+                })}
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {activeTab.quickLinks.map((link) => (
+                  <Link
+                    key={`${activeTab.id}-${link.href}`}
+                    href={link.href}
+                    className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs font-medium text-neutral-100 transition hover:border-brand-primary/60 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60"
+                    onClick={() => {
+                      trackMegaMenuInteraction({
+                        tab: activeTab,
+                        linkLabel: link.label,
+                        href: link.href,
+                        context: 'quick-link'
+                      })
+                      onNavigate?.()
+                      handleClose()
+                    }}
+                  >
+                    <span>{link.label}</span>
+                    <ChevronRight className="h-3 w-3 text-brand-primary/80" aria-hidden />
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            <div
+              id={`mega-panel-${activeTab.id}`}
+              role="tabpanel"
+              aria-labelledby={`mega-tab-${activeTab.id}`}
+              className="grid gap-6 md:grid-cols-3"
+            >
+              {activeTab.columns.map((column) => (
+                <div key={`${activeTab.id}-${column.title}`} className="space-y-3">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-brand-primary/70">
+                    {column.title}
+                  </p>
+                  <ul className="space-y-2">
+                    {column.links.map((link: MegaMenuLink) => (
+                      <li key={`${column.title}-${link.href}`}>
+                        <Link
+                          href={link.href}
+                          className="group block rounded-xl border border-white/5 bg-white/5 px-3 py-2 transition hover:border-brand-primary/60 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60"
+                          onClick={() => {
+                            trackMegaMenuInteraction({
+                              tab: activeTab,
+                              linkLabel: link.label,
+                              href: link.href,
+                              context: 'column',
+                              columnTitle: column.title
+                            })
+                            onNavigate?.()
+                            handleClose()
+                          }}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div>
+                              <p className="text-sm font-semibold text-neutral-50">{link.label}</p>
+                              {link.description && (
+                                <p className="mt-0.5 text-xs text-neutral-300">{link.description}</p>
+                              )}
+                            </div>
+                            <ChevronRight className="mt-1 h-4 w-4 flex-shrink-0 text-brand-primary/80 transition group-hover:translate-x-0.5" aria-hidden />
+                          </div>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+
+            <div className="flex justify-end">
+              <Link
+                href={`/coleccion/${activeTab.collectionSlug}?persona=${activeTab.personaFacet}`}
+                className="inline-flex items-center gap-2 rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
+                onClick={() => {
+                  trackMegaMenuInteraction({
+                    tab: activeTab,
+                    linkLabel: activeTab.ctaLabel,
+                    href: `/coleccion/${activeTab.collectionSlug}?persona=${activeTab.personaFacet}`,
+                    context: 'cta'
+                  })
+                  onNavigate?.()
+                  handleClose()
+                }}
+              >
+                {activeTab.ctaLabel}
+                <ChevronRight className="h-4 w-4" aria-hidden />
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function MobileMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
+  const tabs = megaMenuConfig.tabs
+  const [openTab, setOpenTab] = useState<string | null>(null)
+
+  if (!tabs.length) {
+    return null
+  }
+
+  return (
+    <div className="space-y-4 md:hidden">
+      <p className="text-xs font-semibold uppercase tracking-wide text-brand-primary/80">Colecciones</p>
+      <div className="space-y-3">
+        {tabs.map((tab) => {
+          const isOpen = openTab === tab.id
+          const panelId = `mega-mobile-${tab.id}`
+          const ctaHref = `/coleccion/${tab.collectionSlug}?persona=${tab.personaFacet}`
+          return (
+            <div key={tab.id} className="overflow-hidden rounded-2xl border border-white/5 bg-white/5">
+              <button
+                type="button"
+                className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left text-sm font-semibold text-neutral-50 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
+                aria-expanded={isOpen}
+                aria-controls={panelId}
+                onClick={() => {
+                  setOpenTab((current) => (current === tab.id ? null : tab.id))
+                }}
+              >
+                <span>{tab.label}</span>
+                <ChevronDown
+                  className={`h-4 w-4 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+                  aria-hidden
+                />
+              </button>
+
+              <div
+                id={panelId}
+                className={`space-y-4 border-t border-white/5 px-4 pb-4 pt-4 text-sm text-neutral-100 transition ${
+                  isOpen ? 'opacity-100' : 'hidden opacity-0'
+                }`}
+              >
+                <p className="text-neutral-300">{tab.description}</p>
+
+                <div className="flex flex-wrap gap-2">
+                  {tab.quickLinks.map((link) => (
+                    <Link
+                      key={`${tab.id}-${link.href}`}
+                      href={link.href}
+                      className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs font-medium text-neutral-100 transition hover:border-brand-primary/50 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
+                      onClick={() => {
+                        trackMegaMenuInteraction({
+                          tab,
+                          linkLabel: link.label,
+                          href: link.href,
+                          context: 'quick-link'
+                        })
+                        onNavigate?.()
+                        setOpenTab(null)
+                      }}
+                    >
+                      <span>{link.label}</span>
+                      <ChevronRight className="h-3 w-3 text-brand-primary/80" aria-hidden />
+                    </Link>
+                  ))}
+                </div>
+
+                <div className="space-y-3">
+                  {tab.columns.map((column) => (
+                    <div key={`${tab.id}-${column.title}`}>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-brand-primary/70">
+                        {column.title}
+                      </p>
+                      <ul className="mt-2 space-y-2">
+                        {column.links.map((link) => (
+                          <li key={`${column.title}-${link.href}`}>
+                            <Link
+                              href={link.href}
+                              className="block rounded-xl border border-white/5 bg-white/10 px-3 py-2 text-sm transition hover:border-brand-primary/60 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
+                              onClick={() => {
+                                trackMegaMenuInteraction({
+                                  tab,
+                                  linkLabel: link.label,
+                                  href: link.href,
+                                  context: 'column',
+                                  columnTitle: column.title
+                                })
+                                onNavigate?.()
+                                setOpenTab(null)
+                              }}
+                            >
+                              <div className="flex items-start justify-between gap-3">
+                                <div>
+                                  <p className="text-sm font-semibold text-neutral-50">{link.label}</p>
+                                  {link.description && (
+                                    <p className="mt-0.5 text-xs text-neutral-300">{link.description}</p>
+                                  )}
+                                </div>
+                                <ChevronRight className="mt-1 h-4 w-4 flex-shrink-0 text-brand-primary/80" aria-hidden />
+                              </div>
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+
+                <Link
+                  href={ctaHref}
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
+                  onClick={() => {
+                    trackMegaMenuInteraction({
+                      tab,
+                      linkLabel: tab.ctaLabel,
+                      href: ctaHref,
+                      context: 'cta'
+                    })
+                    onNavigate?.()
+                    setOpenTab(null)
+                  }}
+                >
+                  {tab.ctaLabel}
+                  <ChevronRight className="h-4 w-4" aria-hidden />
+                </Link>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default function MegaMenu({ variant = 'desktop', onNavigate }: MegaMenuProps) {
+  if (variant === 'mobile') {
+    return <MobileMegaMenu onNavigate={onNavigate} />
+  }
+
+  return <DesktopMegaMenu onNavigate={onNavigate} />
+}

--- a/data/collections.json
+++ b/data/collections.json
@@ -1,5 +1,50 @@
 [
   {
+    "slug": "para-ella",
+    "name": "Para ella",
+    "headline": "Sensaciones centradas en tu anatomía",
+    "description": "Vibradores, succionadores y accesorios pensados para el placer vulva-clitoral y una exploración segura.",
+    "rule": {
+      "anyOf": {
+        "tags": ["persona:her"]
+      }
+    },
+    "seo": {
+      "title": "Colección para ella — SexShop del Perú 69",
+      "description": "Elige vibradores, succionadores y complementos creados para acompañar tu ritmo y explorar nuevas sensaciones."
+    }
+  },
+  {
+    "slug": "para-el",
+    "name": "Para él",
+    "headline": "Controla el ritmo y potencia la intensidad",
+    "description": "Mangas, anillos y accesorios que potencian la estimulación peneana, con opciones para entrenar resistencia.",
+    "rule": {
+      "anyOf": {
+        "tags": ["persona:him", "uso:pene"]
+      }
+    },
+    "seo": {
+      "title": "Colección para él — SexShop del Perú 69",
+      "description": "Descubre masturbadores realistas, anillos y herramientas para estimular y entrenar el placer masculino."
+    }
+  },
+  {
+    "slug": "para-parejas",
+    "name": "Para parejas",
+    "headline": "Sincroniza el placer y compartan sensaciones",
+    "description": "Juguetes diseñados para disfrutarse en conjunto, con vibraciones, straps y accesorios que despiertan la complicidad.",
+    "rule": {
+      "anyOf": {
+        "tags": ["persona:couples"]
+      }
+    },
+    "seo": {
+      "title": "Colección para parejas — SexShop del Perú 69",
+      "description": "Explora vibradores, arneses y accesorios que se adaptan a juegos en pareja y expanden las posibilidades."
+    }
+  },
+  {
     "slug": "juegos-en-pareja",
     "name": "Juegos en pareja",
     "headline": "Vibraciones para disfrutar juntos",

--- a/data/mega-menu.config.ts
+++ b/data/mega-menu.config.ts
@@ -1,0 +1,272 @@
+export type MegaMenuLink = {
+  label: string
+  href: string
+  description?: string
+}
+
+export type MegaMenuColumn = {
+  title: string
+  links: MegaMenuLink[]
+}
+
+export type MegaMenuQuickLink = {
+  label: string
+  href: string
+}
+
+export type MegaMenuTab = {
+  id: string
+  label: string
+  tagline: string
+  description: string
+  personaFacet: 'her' | 'him' | 'couples'
+  collectionSlug: string
+  ctaLabel: string
+  quickLinks: MegaMenuQuickLink[]
+  columns: MegaMenuColumn[]
+}
+
+export type MegaMenuConfig = {
+  tabs: MegaMenuTab[]
+}
+
+export const megaMenuConfig: MegaMenuConfig = {
+  tabs: [
+    {
+      id: 'for-her',
+      label: 'Para ella',
+      tagline: 'Placer centrado en vulva y clítoris',
+      description:
+        'Vibradores, succionadores y accesorios que acompañan tu ritmo para descubrir nuevas sensaciones con confianza.',
+      personaFacet: 'her',
+      collectionSlug: 'para-ella',
+      ctaLabel: 'Ver colección para ella',
+      quickLinks: [
+        { label: 'Succionadores', href: '/categoria/clitorales' },
+        { label: 'Vibradores rabbit', href: '/categoria/rabbits' },
+        { label: 'Lubricantes íntimos', href: '/categoria/lubricantes' }
+      ],
+      columns: [
+        {
+          title: 'Vibradores y succionadores',
+          links: [
+            {
+              label: 'Succionadores clitorales',
+              description: 'Estímulo preciso sin contacto directo',
+              href: '/categoria/clitorales'
+            },
+            {
+              label: 'Vibradores rabbit',
+              description: 'Doble estimulación sincronizada',
+              href: '/categoria/rabbits'
+            },
+            {
+              label: 'Vibradores clásicos',
+              description: 'Formas versátiles para principiantes',
+              href: '/categoria/clasicos'
+            },
+            {
+              label: 'Vibradores anales',
+              description: 'Curvas suaves para experimentar',
+              href: '/categoria/anales'
+            }
+          ]
+        },
+        {
+          title: 'Otras texturas y formas',
+          links: [
+            {
+              label: 'Consoladores realistas',
+              description: 'Materiales suaves con detalles anatómicos',
+              href: '/categoria/consoladores'
+            },
+            {
+              label: 'Strapless y dobles',
+              description: 'Diseños sin arnés para compartir sensaciones',
+              href: '/categoria/dobles'
+            },
+            {
+              label: 'Juguetes tipo wand',
+              description: 'Masajeadores de alta potencia para todo el cuerpo',
+              href: '/categoria/extremo'
+            }
+          ]
+        },
+        {
+          title: 'Bienestar y autocuidado',
+          links: [
+            {
+              label: 'Lubricantes y geles',
+              description: 'Compatibles con juguetes y piel sensible',
+              href: '/categoria/lubricantes'
+            },
+            {
+              label: 'Bolas chinas y Kegel',
+              description: 'Fortalece el suelo pélvico con diferentes niveles',
+              href: '/categoria/bolaschinas'
+            },
+            {
+              label: 'Feromonas y aromas',
+              description: 'Fragancias afrodisíacas y aceites seductores',
+              href: '/categoria/feromonas'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'for-him',
+      label: 'Para él',
+      tagline: 'Estimulación enfocada en pene y perineo',
+      description:
+        'Mangas, anillos y accesorios que potencian la intensidad, ayudan a entrenar el control y abren nuevas experiencias.',
+      personaFacet: 'him',
+      collectionSlug: 'para-el',
+      ctaLabel: 'Ver colección para él',
+      quickLinks: [
+        { label: 'Masturbadores realistas', href: '/categoria/fleshlight' },
+        { label: 'Anillos vibradores', href: '/categoria/anillos' },
+        { label: 'Bombas de vacío', href: '/categoria/bombas-succionadoras' }
+      ],
+      columns: [
+        {
+          title: 'Mangas y masturbadores',
+          links: [
+            {
+              label: 'Fleshlight y realistas',
+              description: 'Texturas que envuelven con sensaciones fieles',
+              href: '/categoria/fleshlight'
+            },
+            {
+              label: 'Mangas compactas',
+              description: 'Opciones discretas para uso frecuente',
+              href: '/categoria/masturbadores'
+            },
+            {
+              label: 'Automáticos y high-tech',
+              description: 'Vibración, calor o empuje asistido',
+              href: '/categoria/mega'
+            }
+          ]
+        },
+        {
+          title: 'Control del rendimiento',
+          links: [
+            {
+              label: 'Anillos y cockrings',
+              description: 'Mantén la firmeza y agrega vibración',
+              href: '/categoria/anillos'
+            },
+            {
+              label: 'Geles retardantes',
+              description: 'Dosificación precisa para prolongar el encuentro',
+              href: '/categoria/retardantes'
+            },
+            {
+              label: 'Desarrolladores',
+              description: 'Bombas y extensores para entrenamiento gradual',
+              href: '/categoria/desarrolladores'
+            }
+          ]
+        },
+        {
+          title: 'Exploración avanzada',
+          links: [
+            {
+              label: 'Plugs y masaje prostático',
+              description: 'Curvas ergonómicas y vibración interna',
+              href: '/categoria/plugs'
+            },
+            {
+              label: 'Fundas texturizadas',
+              description: 'Añade grosor y relieve a tus encuentros',
+              href: '/categoria/fundas'
+            },
+            {
+              label: 'Bombas de succión',
+              description: 'Sensación de vacío controlada para nuevas sensaciones',
+              href: '/categoria/bombas-succionadoras'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      id: 'for-couples',
+      label: 'Parejas',
+      tagline: 'Sincroniza el placer en dúo o trío',
+      description:
+        'Juguetes que se adaptan a distintas dinámicas, desde vibraciones compartidas hasta roles creativos con arneses y kits.',
+      personaFacet: 'couples',
+      collectionSlug: 'para-parejas',
+      ctaLabel: 'Ver colección para parejas',
+      quickLinks: [
+        { label: 'Arneses y strap-ons', href: '/categoria/arneses-protesis' },
+        { label: 'Juegos anales en conjunto', href: '/categoria/plugs' },
+        { label: 'Ambiente sensorial', href: '/categoria/feromonas' }
+      ],
+      columns: [
+        {
+          title: 'Para compartir vibraciones',
+          links: [
+            {
+              label: 'Vibradores para parejas',
+              description: 'Modelos que acompañan la penetración',
+              href: '/categoria/vibradores'
+            },
+            {
+              label: 'Arneses y strap-ons',
+              description: 'Cambia roles y posiciones con seguridad',
+              href: '/categoria/arneses-protesis'
+            },
+            {
+              label: 'Anillos vibradores',
+              description: 'Vibración sincronizada para ambos cuerpos',
+              href: '/categoria/anillos'
+            }
+          ]
+        },
+        {
+          title: 'Nuevas dinámicas',
+          links: [
+            {
+              label: 'Plugs y estimulación anal',
+              description: 'Progresa en conjunto con tamaños graduales',
+              href: '/categoria/plugs'
+            },
+            {
+              label: 'Consoladores dobles',
+              description: 'Diseños flexibles para usar al mismo tiempo',
+              href: '/categoria/dobles'
+            },
+            {
+              label: 'Elementos BDSM y juegos',
+              description: 'Ataduras suaves, antifaces y fetiches',
+              href: '/categoria/sadobondage'
+            }
+          ]
+        },
+        {
+          title: 'Ambientación y sensorial',
+          links: [
+            {
+              label: 'Lubricantes y potenciadores',
+              description: 'Sensaciones cálidas, frías o con sabores',
+              href: '/categoria/lubricantes'
+            },
+            {
+              label: 'Feromonas y perfumes',
+              description: 'Fragancias afrodisíacas para cada ocasión',
+              href: '/categoria/feromonas'
+            },
+            {
+              label: 'Fetiches y roleplay',
+              description: 'Accesorios coquetos para subir la temperatura',
+              href: '/categoria/fetiches'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add persona-focused collections data and mega menu configuration
- build a shared mega menu component with GA4 tracking, desktop hover, and mobile accordion modes
- replace the header navigation categories block with the new mega menu implementation

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68db0fa2c7dc832183aead03f7df1d6d