### PR TITLE
feat: refresh brand palette and utilities

### DIFF
--- a/app/ads/variant-a/page.tsx
+++ b/app/ads/variant-a/page.tsx
@@ -8,7 +8,7 @@
         <li>Pagos seguros y discretos</li>
         <li>Asesoría personalizada</li>
       </ul>
-      <a href="/categoria/bienestar" className="inline-block mt-6 px-5 py-3 rounded-xl bg-brand-primary text-white">Explorar Bienestar</a>
+      <a href="/categoria/bienestar" className="btn-primary mt-6">Explorar Bienestar</a>
     </main>
   )
 }

--- a/app/ads/variant-b/page.tsx
+++ b/app/ads/variant-b/page.tsx
@@ -3,7 +3,7 @@
     <main className="max-w-3xl mx-auto py-10">
       <h1 className="text-3xl font-semibold">Atención discreta y profesional</h1>
       <p className="mt-3 text-neutral-700">Asesoría clínica, lenguaje respetuoso, contenido para mayores de 18. Este entorno de pruebas cumple con lineamientos de anuncios.</p>
-      <a href="/categoria/kits" className="inline-block mt-6 px-5 py-3 rounded-xl bg-brand-primary text-white">Ver Kits</a>
+      <a href="/categoria/kits" className="btn-primary mt-6">Ver Kits</a>
     </main>
   )
 }

--- a/app/categoria/[slug]/category-filters-client.tsx
+++ b/app/categoria/[slug]/category-filters-client.tsx
@@ -228,14 +228,14 @@ export default function CategoryFiltersClient() {
               onChange={(event) => onQueryChange(event.target.value)}
               placeholder="Buscar en la categoría"
               aria-label="Buscar"
-              className="flex-1 rounded-xl border border-neutral-200 px-4 py-2 text-sm shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+              className="flex-1 rounded-xl border border-neutral-200 px-4 py-2 text-sm shadow-sm focus:border-brand-pink focus:outline-none focus:ring-2 focus:ring-brand-pink/40"
             />
             <div className="relative">
               <button
                 type="button"
                 aria-expanded={isSheetOpen}
                 aria-haspopup="dialog"
-                className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-neutral-200 px-3 py-2 text-sm font-medium text-neutral-700 shadow-sm transition hover:border-brand-primary/60 hover:text-brand-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary sm:w-auto"
+                className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-neutral-200 px-3 py-2 text-sm font-medium text-neutral-700 shadow-sm transition hover:border-brand-pink/60 hover:text-brand-pink focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-pink sm:w-auto"
                 onClick={() => setIsSheetOpen((prev) => !prev)}
               >
                 Filtros

--- a/app/checkout/success/SuccessClient.tsx
+++ b/app/checkout/success/SuccessClient.tsx
@@ -23,7 +23,7 @@ export default function SuccessClient() {
     <main className="max-w-lg mx-auto text-center py-12">
       <h1 className="text-2xl font-semibold">Checkout sandbox</h1>
       <p className="mt-2">Pedido simulado para <b>{sku}</b>. Aquí conectaremos la pasarela (Culqi/Niubiz) tras aprobación.</p>
-      <a href="/" className="inline-block mt-6 px-5 py-3 rounded-xl bg-brand-primary text-white">Volver al inicio</a>
+      <a href="/" className="btn-primary mt-6">Volver al inicio</a>
     </main>
   )
 }

--- a/app/coleccion/[slug]/collection-filters-client.tsx
+++ b/app/coleccion/[slug]/collection-filters-client.tsx
@@ -109,14 +109,14 @@ export default function CollectionFiltersClient({
               onChange={event => onQueryChange(event.target.value)}
               placeholder="Buscar en la colección"
               aria-label="Buscar"
-              className="flex-1 rounded-xl border border-neutral-200 px-4 py-2 text-sm shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+              className="flex-1 rounded-xl border border-neutral-200 px-4 py-2 text-sm shadow-sm focus:border-brand-pink focus:outline-none focus:ring-2 focus:ring-brand-pink/40"
             />
             <div className="relative">
               <button
                 type="button"
                 aria-expanded={isSheetOpen}
                 aria-haspopup="dialog"
-                className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-neutral-200 px-3 py-2 text-sm font-medium text-neutral-700 shadow-sm transition hover:border-brand-primary/60 hover:text-brand-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary sm:w-auto"
+                className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-neutral-200 px-3 py-2 text-sm font-medium text-neutral-700 shadow-sm transition hover:border-brand-pink/60 hover:text-brand-pink focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-pink sm:w-auto"
                 onClick={() => setIsSheetOpen(prev => !prev)}
               >
                 Filtros

--- a/app/coleccion/[slug]/page.tsx
+++ b/app/coleccion/[slug]/page.tsx
@@ -71,7 +71,7 @@ export default function CollectionPage({
     <div>
       <div className="space-y-2">
         <h1 className="text-2xl font-semibold text-neutral-900">{collection.name}</h1>
-        {collection.headline && <p className="text-sm font-medium text-brand-primary">{collection.headline}</p>}
+        {collection.headline && <p className="text-sm font-medium text-brand-pink">{collection.headline}</p>}
         {collection.description && <p className="max-w-2xl text-sm text-neutral-600">{collection.description}</p>}
         <p className="text-xs text-neutral-500">{filteredProducts.length} productos disponibles</p>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,14 +4,18 @@
 
 :root {
   color-scheme: dark;
-  --color-background: #05000f;
-  --color-foreground: #f7f2ff;
-  --color-muted-foreground: #cbbdf5;
-  --color-subtle-foreground: #a99eda;
-  --color-surface: rgba(26, 6, 43, 0.85);
-  --color-surface-strong: #170629;
-  --color-border: rgba(219, 196, 255, 0.25);
-  --color-border-strong: rgba(236, 208, 255, 0.45);
+  --brand-blue: #2551B6;
+  --brand-violet: #624EA9;
+  --brand-pink: #DA469A;
+  --grad: linear-gradient(135deg, var(--brand-blue) 0%, var(--brand-violet) 55%, var(--brand-pink) 100%);
+  --background: #05000f;
+  --foreground: #f7f2ff;
+  --muted-foreground: #cbbdf5;
+  --subtle-foreground: #a99eda;
+  --surface: rgba(26, 6, 43, 0.85);
+  --surface-strong: #170629;
+  --border: rgba(219, 196, 255, 0.25);
+  --border-strong: rgba(236, 208, 255, 0.45);
 }
 
 @font-face {
@@ -28,11 +32,49 @@
     font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   }
   body {
-    background-color: var(--color-background);
-    color: var(--color-foreground);
+    background-color: var(--background);
+    color: var(--foreground);
   }
   ::selection {
-    background-color: rgba(236, 72, 153, 0.65);
+    background-color: rgba(218, 70, 154, 0.65);
     color: #fff;
+  }
+}
+
+@layer components {
+  .btn-primary {
+    @apply inline-flex items-center justify-center gap-2 rounded-full px-5 py-2.5 text-sm font-semibold text-white transition duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2;
+    background: var(--brand-pink);
+    box-shadow: 0 22px 46px -20px rgba(218, 70, 154, 0.6);
+  }
+
+  .btn-primary:hover {
+    filter: brightness(1.06);
+  }
+
+  .btn-primary:active {
+    transform: translateY(1px);
+  }
+
+  .btn-gradient {
+    @apply inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 text-base font-semibold text-white transition duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2;
+    background-image: var(--grad);
+    box-shadow: 0 28px 60px -24px rgba(37, 81, 182, 0.55);
+  }
+
+  .btn-gradient:hover {
+    filter: brightness(1.04);
+  }
+
+  .btn-gradient:active {
+    transform: translateY(1px);
+  }
+
+  .logo-69 {
+    background-image: var(--grad);
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+    text-shadow: 0 0 18px rgba(98, 78, 169, 0.35);
   }
 }

--- a/app/producto/[slug]/page.tsx
+++ b/app/producto/[slug]/page.tsx
@@ -117,7 +117,7 @@ export default function ProductPage({ params }: { params: { slug: string } }) {
           <h1 className="text-2xl font-semibold mt-1">{product.name}</h1>
           <div className="mt-2 flex flex-col gap-3">
             <div className="flex flex-wrap items-center gap-3">
-              <div className="flex items-baseline gap-2 text-brand-primary">
+              <div className="flex items-baseline gap-2 text-brand-pink">
                 <span className="text-3xl font-bold md:text-4xl">S/ {displayPrice}</span>
                 {hasSalePrice && (
                   <span className="text-lg font-semibold text-neutral-400 line-through">S/ {regularPrice}</span>
@@ -129,9 +129,9 @@ export default function ProductPage({ params }: { params: { slug: string } }) {
                 </span>
               )}
             </div>
-            <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-brand-primary">
-              <span className="inline-flex items-center rounded-full bg-brand-primary/10 px-3 py-1">Envío 100% discreto</span>
-              <span className="inline-flex items-center rounded-full bg-brand-primary/10 px-3 py-1">Empaque sin logos</span>
+            <div className="flex flex-wrap items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-brand-pink">
+              <span className="inline-flex items-center rounded-full bg-brand-pink/10 px-3 py-1">Envío 100% discreto</span>
+              <span className="inline-flex items-center rounded-full bg-brand-pink/10 px-3 py-1">Empaque sin logos</span>
             </div>
           </div>
           <div className="text-sm text-neutral-500 mt-1">
@@ -142,7 +142,7 @@ export default function ProductPage({ params }: { params: { slug: string } }) {
             <ul className="mt-4 space-y-2 rounded-2xl bg-neutral-50 p-4 text-sm text-neutral-700">
               {bulletPoints.map(point => (
                 <li key={point.label} className="flex items-start gap-2">
-                  <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-brand-primary/60" aria-hidden />
+                  <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-brand-pink/60" aria-hidden />
                   <div>
                     <span className="font-semibold text-neutral-900">{point.label}:</span> {point.value}
                   </div>
@@ -155,7 +155,7 @@ export default function ProductPage({ params }: { params: { slug: string } }) {
             {/* Este enlace simula la compra y envía los datos a la página de éxito para la conversión */}
             <Link
               href={checkoutHref}
-              className="group inline-flex flex-1 flex-col items-center justify-center gap-1 rounded-2xl bg-brand-primary px-6 py-4 text-center text-white shadow-lg transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+              className="btn-primary group inline-flex flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-6 py-4 text-center transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl"
             >
               <span className="text-base font-semibold">Comprar ahora</span>
               <span className="text-xs text-white/80">Checkout seguro y discreto</span>
@@ -164,10 +164,10 @@ export default function ProductPage({ params }: { params: { slug: string } }) {
               href={whatsappHref}
               target="_blank"
               rel="noreferrer"
-              className="group inline-flex flex-1 flex-col items-center justify-center gap-1 rounded-2xl border border-brand-primary/20 bg-white px-6 py-4 text-center text-brand-primary shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-brand-primary/40 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+              className="group inline-flex flex-1 flex-col items-center justify-center gap-1 rounded-2xl border border-brand-pink/20 bg-white px-6 py-4 text-center text-brand-pink shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-brand-pink/40 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-pink"
             >
               <span className="text-base font-semibold">WhatsApp 24/7</span>
-              <span className="text-xs text-brand-primary/80">Resolvemos tus dudas en minutos</span>
+              <span className="text-xs text-brand-pink/80">Resolvemos tus dudas en minutos</span>
             </a>
           </div>
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -61,7 +61,7 @@ export default function Header() {
         initial={{ y: -24, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         transition={{ duration: 0.35, ease: 'easeOut' }}
-        className={`sticky top-0 z-40 border-b border-brand-primary/60 backdrop-blur-xl transition-colors duration-300 ${
+        className={`sticky top-0 z-40 border-b border-brand-pink/60 backdrop-blur-xl transition-colors duration-300 ${
           isScrolled
             ? 'bg-neutral-950/70 supports-[backdrop-filter]:bg-neutral-950/60'
             : 'bg-neutral-950 supports-[backdrop-filter]:bg-neutral-950'
@@ -70,14 +70,14 @@ export default function Header() {
         <header className="mx-auto flex h-14 w-full max-w-7xl items-center justify-between px-3 text-neutral-100 sm:px-4">
           <Link
             href="/"
-            className="flex items-center gap-2 rounded-full px-3 py-1 text-sm font-semibold tracking-tight text-brand-primary transition hover:bg-brand-primary/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60 md:text-base"
+            className="flex items-center gap-2 rounded-full px-3 py-1 text-sm font-semibold tracking-tight text-brand-pink transition hover:bg-brand-pink/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/60 md:text-base"
           >
-            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand-primary text-base font-bold uppercase">
+            <span className="logo-69 inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-base font-bold uppercase">
               69
             </span>
             <span className="flex flex-col leading-tight">
               <span>SexShop del Perú</span>
-              <span className="text-[0.65rem] font-medium uppercase tracking-[0.3em] text-brand-primary/80 md:text-xs">
+              <span className="text-[0.65rem] font-medium uppercase tracking-[0.3em] text-brand-pink/80 md:text-xs">
                 Placer sin tabúes
               </span>
             </span>
@@ -89,7 +89,7 @@ export default function Header() {
               <Link
                 key={link.href}
                 href={link.href}
-                className="rounded-full px-3 py-2 text-brand-primary/90 transition hover:bg-brand-primary/15 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60"
+                className="rounded-full px-3 py-2 text-brand-pink/90 transition hover:bg-brand-pink/15 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/60"
               >
                 {link.label}
               </Link>
@@ -100,7 +100,7 @@ export default function Header() {
             <button
               type="button"
               onClick={openSearch}
-              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-brand-primary transition hover:border-brand-primary/60 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70 md:w-auto md:px-3"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-brand-pink transition hover:border-brand-pink/60 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70 md:w-auto md:px-3"
               aria-label="Abrir buscador"
             >
               <Search className="h-4 w-4" aria-hidden />
@@ -109,7 +109,7 @@ export default function Header() {
 
             <Link
               href="/carrito"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-brand-primary transition hover:border-brand-primary/60 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70 md:w-auto md:px-3"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-brand-pink transition hover:border-brand-pink/60 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70 md:w-auto md:px-3"
               aria-label="Abrir carrito"
             >
               <ShoppingBag className="h-4 w-4" aria-hidden />
@@ -119,7 +119,7 @@ export default function Header() {
             <button
               type="button"
               onClick={openChat}
-              className="inline-flex h-10 items-center justify-center gap-2 rounded-full border border-brand-primary/40 bg-brand-primary/20 px-4 text-sm font-semibold text-brand-primary transition hover:border-brand-primary/50 hover:bg-brand-primary/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
+              className="btn-primary h-10 px-5"
             >
               <MessageCircle className="h-4 w-4" aria-hidden />
               <span className="hidden md:inline">Asistente</span>
@@ -129,7 +129,7 @@ export default function Header() {
             <button
               type="button"
               aria-label={menuOpen ? 'Cerrar menú' : 'Abrir menú'}
-              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-brand-primary transition hover:border-brand-primary/60 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70 md:hidden"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/5 text-brand-pink transition hover:border-brand-pink/60 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70 md:hidden"
               onClick={toggleMenu}
             >
               {menuOpen ? <X className="h-5 w-5" aria-hidden /> : <Menu className="h-5 w-5" aria-hidden />}
@@ -162,11 +162,11 @@ export default function Header() {
                 className="flex h-full w-[min(20rem,85vw)] flex-col bg-neutral-950/95 text-neutral-100 shadow-2xl"
               >
                 <div className="flex items-center justify-between px-4 pb-2 pt-4">
-                  <p className="text-sm font-semibold uppercase tracking-[0.2em] text-brand-primary/80">Explorar</p>
+                  <p className="text-sm font-semibold uppercase tracking-[0.2em] text-brand-pink/80">Explorar</p>
                   <button
                     type="button"
                     onClick={toggleMenu}
-                    className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 text-brand-primary transition hover:border-brand-primary/60 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 text-brand-pink transition hover:border-brand-pink/60 hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70"
                   >
                     <X className="h-4 w-4" aria-hidden />
                     <span className="sr-only">Cerrar menú</span>
@@ -177,13 +177,13 @@ export default function Header() {
                     <nav className="space-y-6">
                       <MegaMenu variant="mobile" onNavigate={() => setMenuOpen(false)} />
                       <div className="space-y-2">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-brand-primary/80">Descubre más</p>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-brand-pink/80">Descubre más</p>
                         {primaryLinks.map((link) => (
                           <Link
                             key={link.href}
                             href={link.href}
                             onClick={() => setMenuOpen(false)}
-                            className="block rounded-xl border border-white/5 bg-white/5 px-3 py-2 text-sm transition hover:border-brand-primary/40 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
+                            className="block rounded-xl border border-white/5 bg-white/5 px-3 py-2 text-sm transition hover:border-brand-pink/40 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70"
                           >
                             {link.label}
                           </Link>
@@ -204,7 +204,7 @@ export default function Header() {
                       openChat()
                       setMenuOpen(false)
                     }}
-                    className="flex w-full items-center justify-center gap-2 rounded-xl bg-brand-primary px-4 py-3 text-sm font-semibold text-white transition hover:bg-brand-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
+                    className="btn-primary flex w-full items-center justify-center gap-2 rounded-xl px-4 py-3 text-sm"
                   >
                     <MessageCircle className="h-4 w-4" aria-hidden />
                     Abrir asistente

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -8,10 +8,10 @@ import { AnimatePresence, motion, type HTMLMotionProps } from 'framer-motion'
 const AUTO_PLAY_DELAY = 9000
 
 const baseButtonClasses =
-  'inline-flex items-center justify-center rounded-full px-6 py-3 text-base font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white'
+  'inline-flex items-center justify-center rounded-full px-6 py-3 text-base font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-pink'
 
-const primaryButtonClasses = `${baseButtonClasses} bg-white text-neutral-900 shadow-xl shadow-black/30 hover:bg-neutral-200`
-const secondaryButtonClasses = `${baseButtonClasses} border border-white/40 bg-white/10 text-white backdrop-blur hover:bg-white/20`
+const primaryButtonClasses = 'btn-gradient'
+const secondaryButtonClasses = `${baseButtonClasses} border border-white/40 bg-white/10 text-white backdrop-blur hover:border-white/60 hover:bg-white/15`
 
 type SlideMedia = { type: 'image'; src: string; alt: string }
 
@@ -197,7 +197,7 @@ export default function Hero() {
                     sizes="40vw"
                     className="object-cover object-center"
                   />
-                  <div className="absolute inset-0 bg-gradient-to-br from-brand-primary/30 via-transparent to-brand-accent/30 mix-blend-screen" />
+                  <div className="absolute inset-0 bg-gradient-to-br from-brand-pink/30 via-transparent to-brand-violet/30 mix-blend-screen" />
                 </MotionContent>
               </AnimatePresence>
             </div>

--- a/components/NSFWGallery.tsx
+++ b/components/NSFWGallery.tsx
@@ -39,7 +39,7 @@ export default function NSFWGallery({ slug, count }: { slug: string; count: numb
         <div className="w-full h-full flex flex-col items-center justify-center p-4 text-center">
           <div className="text-sm font-medium">Imágenes sensibles — sólo para mayores de 18</div>
           <p className="text-xs text-neutral-600 mt-1">Al continuar confirma su intención de ver imágenes del producto.</p>
-          <button onClick={() => setShow(true)} className="mt-3 px-4 py-2 rounded-xl bg-brand-primary text-white">Mostrar imágenes</button>
+          <button onClick={() => setShow(true)} className="btn-primary mt-3">Mostrar imágenes</button>
         </div>
       ) : (
         <div className="space-y-3">

--- a/components/category/FilterSheet.tsx
+++ b/components/category/FilterSheet.tsx
@@ -34,9 +34,9 @@ const sectionClass = 'space-y-2'
 const sectionTitleClass = 'text-sm font-semibold text-neutral-800'
 const toggleListClass = 'flex flex-wrap gap-2'
 const toggleClassBase =
-  'rounded-full border px-3 py-1 text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary'
-const toggleActiveClass = 'border-brand-primary bg-brand-primary text-white shadow-sm'
-const toggleInactiveClass = 'border-neutral-200 bg-white text-neutral-700 hover:border-brand-primary/60'
+  'rounded-full border px-3 py-1 text-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-pink'
+const toggleActiveClass = 'border-brand-pink bg-brand-pink text-white shadow-sm'
+const toggleInactiveClass = 'border-neutral-200 bg-white text-neutral-700 hover:border-brand-pink/60'
 
 const FACET_LABELS: Record<TagType, string> = {
   persona: 'Colección',
@@ -74,12 +74,12 @@ function FacetCheckboxGroup({
             <label
               key={value}
               htmlFor={safeId}
-              className="flex items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-sm text-neutral-700 transition hover:border-brand-primary/40 hover:bg-brand-primary/5"
+              className="flex items-center gap-2 rounded-lg border border-transparent px-2 py-1 text-sm text-neutral-700 transition hover:border-brand-pink/40 hover:bg-brand-pink/5"
             >
               <input
                 id={safeId}
                 type="checkbox"
-                className="h-4 w-4 rounded border-neutral-300 text-brand-primary focus:ring-brand-primary"
+                className="h-4 w-4 rounded border-neutral-300 text-brand-pink focus:ring-brand-pink"
                 checked={isChecked}
                 onChange={() => onToggle(value)}
               />
@@ -148,7 +148,7 @@ function SelectFilter({
       <label className={sectionTitleClass}>
         {label}
         <select
-          className="mt-1 w-full rounded-lg border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-800 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/40"
+          className="mt-1 w-full rounded-lg border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-800 focus:border-brand-pink focus:outline-none focus:ring-2 focus:ring-brand-pink/40"
           value={value ?? ''}
           onChange={(event) => {
             const selected = event.target.value
@@ -204,7 +204,7 @@ function FilterContent({
         <button
           type="button"
           onClick={onReset}
-          className="text-sm font-medium text-brand-primary hover:underline"
+          className="text-sm font-medium text-brand-pink hover:underline"
         >
           Limpiar
         </button>

--- a/components/header/SearchOverlay.tsx
+++ b/components/header/SearchOverlay.tsx
@@ -119,7 +119,7 @@ export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
             transition={{ duration: 0.25, ease: 'easeOut' }}
           >
             <div className="flex items-center gap-3 border-b border-neutral-100 px-5 py-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-primary/10 text-brand-primary">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-pink/10 text-brand-pink">
                 <Search className="h-5 w-5" />
               </div>
               <input
@@ -133,7 +133,7 @@ export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
               <button
                 type="button"
                 onClick={onClose}
-                className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-neutral-200 text-neutral-500 transition hover:text-brand-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/40"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-neutral-200 text-neutral-500 transition hover:text-brand-pink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/40"
                 aria-label="Cerrar buscador"
               >
                 <X className="h-4 w-4" />
@@ -174,7 +174,7 @@ export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
                               </p>
                             </div>
                             <div className="flex flex-col items-end gap-1 text-right">
-                              <span className="text-sm font-semibold text-brand-primary">S/ {displayPrice}</span>
+                              <span className="text-sm font-semibold text-brand-pink">S/ {displayPrice}</span>
                               {hasSalePrice && (
                                 <span className="text-xs font-medium text-neutral-400 line-through">S/ {regularPrice}</span>
                               )}
@@ -184,7 +184,7 @@ export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
                             <Link
                               href={`/producto/${product.slug}`}
                               onClick={onClose}
-                              className="inline-flex items-center gap-2 rounded-full border border-brand-primary/30 bg-brand-primary/10 px-4 py-2 font-medium text-brand-primary transition hover:bg-brand-primary/20"
+                              className="inline-flex items-center gap-2 rounded-full border border-brand-pink/30 bg-brand-pink/10 px-4 py-2 font-medium text-brand-pink transition hover:bg-brand-pink/20"
                             >
                               Ver producto
                             </Link>
@@ -192,7 +192,7 @@ export default function SearchOverlay({ open, onClose }: SearchOverlayProps) {
                               href={`https://wa.me/51924281623?text=Consulta%20${encodeURIComponent(product.sku)}`}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-4 py-2 font-medium text-neutral-700 transition hover:border-brand-primary/40 hover:text-brand-primary"
+                              className="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-4 py-2 font-medium text-neutral-700 transition hover:border-brand-pink/40 hover:text-brand-pink"
                               onClick={onClose}
                             >
                               <MessageCircle className="h-4 w-4" />
@@ -240,7 +240,7 @@ function highlightMatches(text: string, rawQuery: string) {
     }
     if (matches[index]) {
       highlighted.push(
-        <mark key={`${text}-${index}-${matches[index]}`} className="rounded bg-brand-primary/20 px-1 text-brand-primary">
+        <mark key={`${text}-${index}-${matches[index]}`} className="rounded bg-brand-pink/20 px-1 text-brand-pink">
           {matches[index]}
         </mark>
       )

--- a/components/home/HeroCarousel.tsx
+++ b/components/home/HeroCarousel.tsx
@@ -72,11 +72,10 @@ type HeroCarouselProps = {
 }
 
 const baseButtonClasses =
-  'inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300'
-const primaryButtonClasses =
-  `${baseButtonClasses} bg-fuchsia-600 text-white shadow-neon hover:bg-fuchsia-700`
+  'inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-pink'
+const primaryButtonClasses = 'btn-primary'
 const secondaryButtonClasses =
-  `${baseButtonClasses} border border-neutral-300 bg-transparent text-neutral-700 hover:border-neutral-400 hover:text-neutral-900`
+  `${baseButtonClasses} border border-neutral-300 bg-white/80 text-neutral-700 hover:border-brand-pink/40 hover:text-brand-pink`
 type SlideMotionProps = HTMLMotionProps<'div'> & { className?: string }
 
 const SlideMotion = forwardRef<HTMLDivElement, SlideMotionProps>((props, ref) => <motion.div ref={ref} {...props} />)
@@ -161,17 +160,17 @@ export default function HeroCarousel({
             type="button"
             onClick={handlePrevious}
             aria-label="Ver anterior"
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-neutral-300 bg-white text-neutral-700 shadow-sm transition hover:border-neutral-400 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-neutral-300 bg-white text-neutral-700 shadow-sm transition hover:border-brand-pink/40 hover:text-brand-pink focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-pink"
           >
-            <ChevronLeft className="h-4 w-4 text-fuchsia-600" aria-hidden />
+            <ChevronLeft className="h-4 w-4 text-brand-violet" aria-hidden />
           </button>
           <button
             type="button"
             onClick={handleNext}
             aria-label="Ver siguiente"
-            className="flex h-10 w-10 items-center justify-center rounded-full border border-neutral-300 bg-white text-neutral-700 shadow-sm transition hover:border-neutral-400 hover:text-neutral-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-300"
+            className="flex h-10 w-10 items-center justify-center rounded-full border border-neutral-300 bg-white text-neutral-700 shadow-sm transition hover:border-brand-pink/40 hover:text-brand-pink focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-pink"
           >
-            <ChevronRight className="h-4 w-4 text-fuchsia-600" aria-hidden />
+            <ChevronRight className="h-4 w-4 text-brand-violet" aria-hidden />
           </button>
         </div>
       </div>

--- a/components/nav/MegaMenu.tsx
+++ b/components/nav/MegaMenu.tsx
@@ -153,10 +153,10 @@ function DesktopMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
             handleOpen()
           }
         }}
-        className={`inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60 ${
+        className={`inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/60 ${
           open
-            ? 'bg-brand-primary/20 text-white'
-            : 'text-brand-primary/90 hover:bg-brand-primary/15 hover:text-white'
+            ? 'bg-brand-pink/20 text-white'
+            : 'text-brand-pink/90 hover:bg-brand-pink/15 hover:text-white'
         }`}
       >
         <Sparkles className="h-4 w-4" aria-hidden />
@@ -176,11 +176,11 @@ function DesktopMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
         }`}
         style={{ transform: open ? 'translateY(0.5rem)' : 'translateY(0.25rem)' }}
       >
-        <div className="mx-auto max-w-5xl bg-[#1C1C2B] p-6 text-sm text-white shadow-2xl">
+        <div className="mx-auto max-w-5xl bg-surface-strong p-6 text-sm text-white shadow-2xl">
           <div className="flex flex-col gap-6">
             <div className="flex flex-col gap-4">
               <div className="flex flex-col gap-1">
-                <span className="text-xs font-semibold uppercase tracking-[0.28em] text-brand-primary/80">
+                <span className="text-xs font-semibold uppercase tracking-[0.28em] text-brand-pink/80">
                   {activeTab.tagline}
                 </span>
                 <p className="text-base font-semibold text-neutral-50">{activeTab.label}</p>
@@ -198,10 +198,10 @@ function DesktopMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
                       id={`mega-tab-${tab.id}`}
                       aria-selected={isActive}
                       aria-controls={`mega-panel-${tab.id}`}
-                      className={`rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60 ${
+                      className={`rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/60 ${
                         isActive
-                          ? 'border-brand-primary/70 bg-brand-primary/20 text-white'
-                          : 'border-transparent bg-white/5 text-brand-primary/70 hover:border-brand-primary/40 hover:bg-white/10 hover:text-white'
+                          ? 'border-brand-pink/70 bg-brand-pink/20 text-white'
+                          : 'border-transparent bg-white/5 text-brand-pink/70 hover:border-brand-pink/40 hover:bg-white/10 hover:text-white'
                       }`}
                       onMouseEnter={() => setActiveTabId(tab.id)}
                       onFocus={() => setActiveTabId(tab.id)}
@@ -218,7 +218,7 @@ function DesktopMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
                   <li key={`${activeTab.id}-${link.href}`}>
                     <Link
                       href={link.href}
-                      className="inline-flex items-center gap-1 text-white/90 transition hover:text-white hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60"
+                      className="inline-flex items-center gap-1 text-white/90 transition hover:text-white hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/60"
                       onClick={() => {
                         trackMegaMenuInteraction({
                           tab: activeTab,
@@ -231,7 +231,7 @@ function DesktopMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
                       }}
                     >
                       <span>{link.label}</span>
-                      <ChevronRight className="h-3 w-3 text-brand-primary/70" aria-hidden />
+                      <ChevronRight className="h-3 w-3 text-brand-pink/70" aria-hidden />
                     </Link>
                   </li>
                 ))}
@@ -246,7 +246,7 @@ function DesktopMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
             >
               {activeTab.columns.map((column) => (
                 <div key={`${activeTab.id}-${column.title}`} className="space-y-3">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-brand-primary/70">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-brand-pink/70">
                     {column.title}
                   </p>
                   <ul className="space-y-2">
@@ -254,7 +254,7 @@ function DesktopMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
                       <li key={`${column.title}-${link.href}`}>
                         <Link
                           href={link.href}
-                          className="group block px-1 py-1 text-sm text-white/90 transition hover:text-white hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/60"
+                          className="group block px-1 py-1 text-sm text-white/90 transition hover:text-white hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/60"
                           onClick={() => {
                             trackMegaMenuInteraction({
                               tab: activeTab,
@@ -274,7 +274,7 @@ function DesktopMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
                                 <p className="mt-0.5 text-xs text-white/70">{link.description}</p>
                               )}
                             </div>
-                            <ChevronRight className="mt-1 h-4 w-4 flex-shrink-0 text-brand-primary/70 transition group-hover:translate-x-0.5" aria-hidden />
+                            <ChevronRight className="mt-1 h-4 w-4 flex-shrink-0 text-brand-pink/70 transition group-hover:translate-x-0.5" aria-hidden />
                           </div>
                         </Link>
                       </li>
@@ -284,25 +284,25 @@ function DesktopMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
               ))}
             </div>
 
-            <div className="flex justify-end">
-              <Link
-                href={`/coleccion/${activeTab.collectionSlug}?persona=${activeTab.personaFacet}`}
-                className="inline-flex items-center gap-2 rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
-                onClick={() => {
-                  trackMegaMenuInteraction({
-                    tab: activeTab,
-                    linkLabel: activeTab.ctaLabel,
-                    href: `/coleccion/${activeTab.collectionSlug}?persona=${activeTab.personaFacet}`,
-                    context: 'cta'
-                  })
-                  onNavigate?.()
-                  handleClose()
-                }}
-              >
-                {activeTab.ctaLabel}
-                <ChevronRight className="h-4 w-4" aria-hidden />
-              </Link>
-            </div>
+              <div className="flex justify-end">
+                <Link
+                  href={`/coleccion/${activeTab.collectionSlug}?persona=${activeTab.personaFacet}`}
+                  className="btn-primary inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm"
+                  onClick={() => {
+                    trackMegaMenuInteraction({
+                      tab: activeTab,
+                      linkLabel: activeTab.ctaLabel,
+                      href: `/coleccion/${activeTab.collectionSlug}?persona=${activeTab.personaFacet}`,
+                      context: 'cta'
+                    })
+                    onNavigate?.()
+                    handleClose()
+                  }}
+                >
+                  {activeTab.ctaLabel}
+                  <ChevronRight className="h-4 w-4" aria-hidden />
+                </Link>
+              </div>
           </div>
         </div>
       </div>
@@ -320,7 +320,7 @@ function MobileMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
 
   return (
     <div className="space-y-4 md:hidden">
-      <p className="text-xs font-semibold uppercase tracking-wide text-brand-primary/80">Colecciones</p>
+      <p className="text-xs font-semibold uppercase tracking-wide text-brand-pink/80">Colecciones</p>
       <div className="space-y-3">
         {tabs.map((tab) => {
           const isOpen = openTab === tab.id
@@ -330,7 +330,7 @@ function MobileMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
             <div key={tab.id} className="overflow-hidden rounded-2xl border border-white/5 bg-white/5">
               <button
                 type="button"
-                className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left text-sm font-semibold text-neutral-50 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
+                className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left text-sm font-semibold text-neutral-50 transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70"
                 aria-expanded={isOpen}
                 aria-controls={panelId}
                 onClick={() => {
@@ -357,7 +357,7 @@ function MobileMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
                     <li key={`${tab.id}-${link.href}`}>
                       <Link
                         href={link.href}
-                        className="inline-flex items-center gap-2 text-white/90 transition hover:text-white hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
+                        className="inline-flex items-center gap-2 text-white/90 transition hover:text-white hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70"
                         onClick={() => {
                           trackMegaMenuInteraction({
                             tab,
@@ -370,7 +370,7 @@ function MobileMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
                         }}
                       >
                         <span>{link.label}</span>
-                        <ChevronRight className="h-3 w-3 text-brand-primary/70" aria-hidden />
+                        <ChevronRight className="h-3 w-3 text-brand-pink/70" aria-hidden />
                       </Link>
                     </li>
                   ))}
@@ -379,7 +379,7 @@ function MobileMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
                 <div className="space-y-3">
                   {tab.columns.map((column) => (
                     <div key={`${tab.id}-${column.title}`}>
-                      <p className="text-xs font-semibold uppercase tracking-wide text-brand-primary/70">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-brand-pink/70">
                         {column.title}
                       </p>
                       <ul className="mt-2 space-y-2">
@@ -387,7 +387,7 @@ function MobileMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
                           <li key={`${column.title}-${link.href}`}>
                             <Link
                               href={link.href}
-                              className="block px-1 py-1 text-sm text-white/90 transition hover:text-white hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
+                              className="block px-1 py-1 text-sm text-white/90 transition hover:text-white hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70"
                               onClick={() => {
                                 trackMegaMenuInteraction({
                                   tab,
@@ -407,7 +407,7 @@ function MobileMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
                                       <p className="mt-0.5 text-xs text-white/70">{link.description}</p>
                                     )}
                                   </div>
-                                  <ChevronRight className="mt-1 h-4 w-4 flex-shrink-0 text-brand-primary/70" aria-hidden />
+                                  <ChevronRight className="mt-1 h-4 w-4 flex-shrink-0 text-brand-pink/70" aria-hidden />
                                 </div>
                             </Link>
                           </li>
@@ -417,23 +417,23 @@ function MobileMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
                   ))}
                 </div>
 
-                <Link
-                  href={ctaHref}
-                  className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary/70"
-                  onClick={() => {
-                    trackMegaMenuInteraction({
-                      tab,
-                      linkLabel: tab.ctaLabel,
-                      href: ctaHref,
-                      context: 'cta'
-                    })
-                    onNavigate?.()
-                    setOpenTab(null)
-                  }}
-                >
-                  {tab.ctaLabel}
-                  <ChevronRight className="h-4 w-4" aria-hidden />
-                </Link>
+                  <Link
+                    href={ctaHref}
+                    className="btn-primary inline-flex w-full items-center justify-center gap-2 rounded-full px-4 py-2 text-sm"
+                    onClick={() => {
+                      trackMegaMenuInteraction({
+                        tab,
+                        linkLabel: tab.ctaLabel,
+                        href: ctaHref,
+                        context: 'cta'
+                      })
+                      onNavigate?.()
+                      setOpenTab(null)
+                    }}
+                  >
+                    {tab.ctaLabel}
+                    <ChevronRight className="h-4 w-4" aria-hidden />
+                  </Link>
               </div>
             </div>
           )

--- a/components/product/ProductGallery.tsx
+++ b/components/product/ProductGallery.tsx
@@ -131,7 +131,7 @@ export default function ProductGallery({ slug, name, imageCount, imageFilenames,
                   <button
                     type="button"
                     onClick={handleUnlock}
-                    className="rounded-full bg-brand-primary px-5 py-2 text-sm font-semibold text-white shadow-lg transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+                    className="btn-primary transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-xl"
                   >
                     Ver imágenes
                   </button>
@@ -188,7 +188,7 @@ export default function ProductGallery({ slug, name, imageCount, imageFilenames,
                 onClick={() => setActiveIndex(index)}
                 className={`relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border transition-all duration-200 ${
                   isActive
-                    ? 'border-brand-primary shadow-lg ring-2 ring-brand-primary/30'
+                    ? 'border-brand-pink shadow-lg ring-2 ring-brand-pink/30'
                     : 'border-transparent bg-neutral-100 hover:border-neutral-300'
                 }`}
                 >

--- a/components/product/QuickViewDialog.tsx
+++ b/components/product/QuickViewDialog.tsx
@@ -124,7 +124,7 @@ export default function QuickViewDialog({ product, open, onOpenChange }: QuickVi
                 <button
                   type="button"
                   onClick={() => onOpenChange(false)}
-                  className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/80 text-neutral-500 shadow-md transition hover:bg-white hover:text-neutral-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+                  className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/80 text-neutral-500 shadow-md transition hover:bg-white hover:text-neutral-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-pink"
                   aria-label="Cerrar vista rápida"
                 >
                   <X className="h-5 w-5" />
@@ -176,7 +176,7 @@ export default function QuickViewDialog({ product, open, onOpenChange }: QuickVi
                         {product.badge && <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold uppercase text-amber-700">{product.badge}</span>}
                       </Dialog.Description>
                       <div className="flex flex-wrap items-baseline gap-3">
-                        <span className="text-2xl font-bold text-brand-primary">S/ {displayPrice}</span>
+                        <span className="text-2xl font-bold text-brand-pink">S/ {displayPrice}</span>
                         {hasSalePrice && (
                           <span className="text-base font-medium text-neutral-400 line-through">S/ {regularPrice}</span>
                         )}
@@ -190,7 +190,7 @@ export default function QuickViewDialog({ product, open, onOpenChange }: QuickVi
                         <ul className="space-y-2 rounded-2xl bg-neutral-50 p-4 text-sm text-neutral-700">
                           {features.map((feature, index) => (
                             <li key={index} className="flex items-start gap-2">
-                              <span className="mt-1 h-1.5 w-1.5 rounded-full bg-brand-primary" aria-hidden />
+                              <span className="mt-1 h-1.5 w-1.5 rounded-full bg-brand-pink" aria-hidden />
                               <span>{feature}</span>
                             </li>
                           ))}
@@ -211,7 +211,7 @@ export default function QuickViewDialog({ product, open, onOpenChange }: QuickVi
                     <div className="space-y-3">
                       <Link
                         href={checkoutHref}
-                        className="inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-brand-primary px-4 py-3 text-sm font-semibold text-white shadow-lg transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+                        className="btn-primary w-full gap-2 rounded-2xl px-4 py-3 text-sm shadow-lg transition hover:opacity-95"
                         onClick={() => onOpenChange(false)}
                       >
                         <ShoppingBag className="h-4 w-4" /> Comprar ahora
@@ -220,7 +220,7 @@ export default function QuickViewDialog({ product, open, onOpenChange }: QuickVi
                         href={whatsappHref}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-neutral-200 px-4 py-3 text-sm font-semibold text-neutral-700 shadow-sm transition hover:border-brand-primary hover:text-brand-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+                        className="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-neutral-200 px-4 py-3 text-sm font-semibold text-neutral-700 shadow-sm transition hover:border-brand-pink hover:text-brand-pink focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-pink"
                       >
                         <MessageCircle className="h-4 w-4" /> WhatsApp
                       </a>

--- a/components/ui/Sections.tsx
+++ b/components/ui/Sections.tsx
@@ -16,7 +16,7 @@ export default function Sections({ product }: { product: Product }) {
       {product.descriptionHtml && (
         <Section title="Descripción del producto">
           <div
-            className="space-y-3 text-neutral-700 [&_a]:text-brand-primary [&_a]:underline [&_a:hover]:text-brand-primary/80 [&_li]:ml-5 [&_li]:list-disc [&_ol]:ml-5 [&_ol]:list-decimal [&_p]:leading-relaxed"
+            className="space-y-3 text-neutral-700 [&_a]:text-brand-pink [&_a]:underline [&_a:hover]:text-brand-pink/80 [&_li]:ml-5 [&_li]:list-disc [&_ol]:ml-5 [&_ol]:list-decimal [&_p]:leading-relaxed"
             dangerouslySetInnerHTML={{ __html: product.descriptionHtml }}
           />
         </Section>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,13 +12,34 @@ export default {
         sans: ['Inter', ...defaultTheme.fontFamily.sans]
       },
       colors: {
-        background: '#ffffff',
-        foreground: '#111827',
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
+        muted: {
+          foreground: 'var(--muted-foreground)',
+          subtle: 'var(--subtle-foreground)'
+        },
+        surface: {
+          DEFAULT: 'var(--surface)',
+          strong: 'var(--surface-strong)'
+        },
+        border: {
+          DEFAULT: 'var(--border)',
+          strong: 'var(--border-strong)'
+        },
         brand: {
-          primary: '#ec4899',
-          secondary: '#7c3aed',
-          accent: '#ec4899',
-          highlight: '#7c3aed'
+          DEFAULT: '#DA469A',
+          pink: '#DA469A',
+          violet: '#624EA9',
+          blue: '#2551B6'
+        },
+        neutral: {
+          950: '#05000F',
+          900: '#0B021B',
+          800: '#170629',
+          700: '#26123B',
+          300: '#B8AADC',
+          200: '#CBBDF5',
+          50: '#F7F2FF'
         }
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- replace legacy root palette with brand tokens and add reusable gradient/primary button utilities
- align Tailwind theme with the new brand colors and expose supporting surface/border variables
- migrate key CTAs (header, hero, product flows) to the new utilities to enforce the refreshed color ratio

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68db1f92d6048321b4d318b6602e70d3