### PR TITLE
Add Montserrat heading typography and update header branding

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css'
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import Script from 'next/script'
+import { Montserrat } from 'next/font/google'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import { ChatBubble } from '@/components/ChatBubble'
@@ -9,6 +10,13 @@ import { AgeGate } from '@/components/AgeGate'
 import Tracker from './Tracker'
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL
+
+const montserrat = Montserrat({
+  subsets: ['latin'],
+  weight: ['700', '800'],
+  display: 'swap',
+  variable: '--font-heading'
+})
 
 const baseMetadata: Metadata = {
   title: 'SexShop del Perú 69 — Piloto',
@@ -70,7 +78,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <link rel="preconnect" href="https://plausible.io" />
         )}
       </head>
-      <body className="min-h-screen bg-white text-neutral-900 antialiased">
+      <body className={`${montserrat.variable} min-h-screen bg-white text-neutral-900 antialiased`}>
         <Suspense fallback={null}>
           <Tracker />
         </Suspense>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -136,7 +136,7 @@ export default function Page() {
             className="relative rounded-3xl border border-neutral-200 bg-neutral-50 px-4 py-10 sm:px-6 lg:px-8"
           >
             <div className="relative z-10 space-y-6">
-              <h2 id="buscas-algo-mas-especifico" className="text-xl font-semibold text-neutral-900 lg:text-2xl">
+              <h2 id="buscas-algo-mas-especifico" className="font-heading text-xl font-semibold text-neutral-900 lg:text-2xl">
                 ¿Buscas algo más específico?
               </h2>
               <p className="max-w-2xl text-sm text-neutral-600">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -76,8 +76,13 @@ export default function Header() {
               69
             </span>
             <span className="flex flex-col leading-tight">
-              <span>SexShop del Perú</span>
-              <span className="text-[0.65rem] font-medium uppercase tracking-[0.3em] text-brand-pink/80 md:text-xs">
+              <span className="font-heading text-[0.95rem] font-bold uppercase tracking-[0.02em] md:text-lg">
+                Sex Shop
+              </span>
+              <span className="font-heading text-[0.6rem] font-extrabold uppercase tracking-[0.18em] text-brand-pink/80 md:text-[0.65rem]">
+                Del Perú
+              </span>
+              <span className="text-[0.65rem] font-medium uppercase tracking-[0.3em] text-brand-pink/70 md:text-xs">
                 Placer sin tabúes
               </span>
             </span>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -150,7 +150,7 @@ export default function Hero() {
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.7, ease: 'easeOut' }}
-              className="text-4xl font-semibold leading-tight sm:text-5xl lg:text-[3.6rem] lg:leading-[1.05]"
+              className="font-heading text-4xl font-semibold leading-tight sm:text-5xl lg:text-[3.6rem] lg:leading-[1.05]"
             >
               {activeSlide.title}
             </MotionHeading>

--- a/components/home/BestSellers.tsx
+++ b/components/home/BestSellers.tsx
@@ -100,7 +100,7 @@ export default function BestSellers({
       >
         <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
           <div>
-            <h2 id={headingId} className="text-2xl font-semibold text-neutral-900">
+            <h2 id={headingId} className="font-heading text-2xl font-semibold text-neutral-900">
               {title}
             </h2>
             <p className="text-sm text-neutral-600">{description}</p>

--- a/components/home/CategoryCarousel.tsx
+++ b/components/home/CategoryCarousel.tsx
@@ -74,7 +74,7 @@ export function CategoryCard({
           </div>
         )}
         <div className="flex flex-1 flex-col gap-1 px-4 pb-6 pt-4">
-          <h3 className="text-lg font-extrabold uppercase text-neutral-900">{category.label}</h3>
+          <h3 className="font-heading text-lg font-extrabold uppercase text-neutral-900">{category.label}</h3>
           <p className="truncate text-xs font-semibold uppercase tracking-[0.08em] text-neutral-600">{category.subtitle}</p>
           <p className="truncate text-xs font-semibold uppercase text-neutral-600">{category.description}</p>
         </div>
@@ -124,7 +124,7 @@ export default function CategoryCarousel({ title, subtitle, headingId, categorie
     <section className="space-y-4" id="catalogo">
       {title && (
         <div className="space-y-1">
-          <h2 id={headingId} className="text-xl font-semibold text-neutral-900">
+          <h2 id={headingId} className="font-heading text-xl font-semibold text-neutral-900">
             {title}
           </h2>
           {subtitle && <p className="text-sm text-neutral-600">{subtitle}</p>}

--- a/components/home/FeaturedProducts.tsx
+++ b/components/home/FeaturedProducts.tsx
@@ -37,7 +37,7 @@ export default function FeaturedProducts({ products, headingId }: FeaturedProduc
   return (
     <section className="space-y-8" aria-labelledby={headingId}>
       <div className="space-y-2">
-        <h2 id={headingId} className="text-3xl font-semibold text-neutral-900">
+        <h2 id={headingId} className="font-heading text-3xl font-semibold text-neutral-900">
           Productos destacados
         </h2>
         <p className="max-w-2xl text-sm text-neutral-600">
@@ -81,7 +81,7 @@ export default function FeaturedProducts({ products, headingId }: FeaturedProduc
               <div className="relative space-y-4 p-8">
                 <div className="space-y-2">
                   <span className="inline-flex items-center rounded-full bg-fuchsia-100 px-4 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-fuchsia-700">Premium</span>
-                  <h3 className="text-2xl font-semibold text-neutral-900">{product.name}</h3>
+                  <h3 className="font-heading text-2xl font-semibold text-neutral-900">{product.name}</h3>
                   {product.shortDescription && (
                     <p className="text-sm leading-relaxed text-neutral-600">{product.shortDescription}</p>
                   )}

--- a/components/home/InspirationalBanner.tsx
+++ b/components/home/InspirationalBanner.tsx
@@ -73,7 +73,7 @@ export default function InspirationalBanner({
     <div className="flex flex-col justify-center gap-6 px-8 py-10 text-neutral-900">
       {eyebrow && <span className="text-xs font-semibold uppercase tracking-[0.35em] text-neutral-600">{eyebrow}</span>}
       <div className="space-y-4">
-        <h3 className="text-3xl font-semibold text-neutral-900">{title}</h3>
+        <h3 className="font-heading text-3xl font-semibold text-neutral-900">{title}</h3>
         <p className="text-base leading-relaxed text-neutral-600">{description}</p>
       </div>
       {ctaHref && ctaLabel && (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,7 +9,8 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter', ...defaultTheme.fontFamily.sans]
+        sans: ['Inter', ...defaultTheme.fontFamily.sans],
+        heading: ['var(--font-heading)', 'Montserrat', ...defaultTheme.fontFamily.sans]
       },
       colors: {
         background: 'var(--background)',


### PR DESCRIPTION
## Summary
- add the Montserrat display font with a shared CSS variable and Tailwind heading family
- refresh the header logotype with Montserrat tracking while preserving Inter for body copy
- apply the new heading font across hero, featured, and category sections for consistent titles

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68db235b47c883219cf860772c5fb7a0