### PR TITLE
Update hero CTA styles to use gradient and solid tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -52,6 +52,10 @@
     filter: brightness(1.06);
   }
 
+  .btn-primary:focus-visible {
+    outline-color: rgba(218, 70, 154, 0.85);
+  }
+
   .btn-primary:active {
     transform: translateY(1px);
   }
@@ -66,7 +70,29 @@
     filter: brightness(1.04);
   }
 
+  .btn-gradient:focus-visible {
+    outline-color: rgba(98, 78, 169, 0.8);
+  }
+
   .btn-gradient:active {
+    transform: translateY(1px);
+  }
+
+  .btn-solid-violet {
+    @apply inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 text-base font-semibold text-white transition duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2;
+    background-color: var(--brand-violet);
+    box-shadow: 0 24px 54px -22px rgba(98, 78, 169, 0.55);
+  }
+
+  .btn-solid-violet:hover {
+    filter: brightness(1.05);
+  }
+
+  .btn-solid-violet:focus-visible {
+    outline-color: rgba(98, 78, 169, 0.85);
+  }
+
+  .btn-solid-violet:active {
     transform: translateY(1px);
   }
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -7,11 +7,8 @@ import { AnimatePresence, motion, type HTMLMotionProps } from 'framer-motion'
 
 const AUTO_PLAY_DELAY = 9000
 
-const baseButtonClasses =
-  'inline-flex items-center justify-center rounded-full px-6 py-3 text-base font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-pink'
-
 const primaryButtonClasses = 'btn-gradient'
-const secondaryButtonClasses = `${baseButtonClasses} border border-white/40 bg-white/10 text-white backdrop-blur hover:border-white/60 hover:bg-white/15`
+const secondaryButtonClasses = 'btn-solid-violet'
 
 type SlideMedia = { type: 'image'; src: string; alt: string }
 


### PR DESCRIPTION
## Summary
- apply the new btn-gradient selector to the hero CTA and introduce the solid violet style for the secondary action
- extend the global button tokens with accessible focus states for gradient, primary, and new solid violet variants

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db47df66ac832194f1c35f93a9680b