### PR TITLE
Update primary navigation links

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -17,9 +17,9 @@ const MotionButton: any = motion.button
 const MotionAside: any = motion.aside
 
 const primaryLinks = [
-  { href: '/novedades', label: 'Novedades' },
-  { href: '/ofertas', label: 'Ofertas' },
-  { href: '/blog', label: 'Blog/Guías' },
+  { href: '/coleccion/para-el?persona=him', label: 'Él' },
+  { href: '/coleccion/para-ella?persona=her', label: 'Ella' },
+  { href: '/coleccion/para-parejas?persona=couples', label: 'Parejas' },
 ]
 
 const promoBanner = {


### PR DESCRIPTION
## Summary
- replace the header primary links with Él, Ella, and Parejas destinations
- ensure the same ordering is used across desktop navigation and the mobile "Descubre más" section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db558538e883218c4361f3d64eaefc