### PR TITLE
feat: animate navigation link hover effects

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -103,4 +103,53 @@
     color: transparent;
     text-shadow: 0 0 18px rgba(98, 78, 169, 0.35);
   }
+
+  .nav-link {
+    position: relative;
+    z-index: 0;
+    color: #fff;
+    overflow: hidden;
+    isolation: isolate;
+    transition: color 200ms ease;
+  }
+
+  .nav-link::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: #fff;
+    border-radius: inherit;
+    transform: translateY(101%);
+    transform-origin: bottom;
+    transition: transform 240ms ease;
+    z-index: -1;
+  }
+
+  .nav-link:hover,
+  .nav-link:focus-visible {
+    color: #05000f;
+  }
+
+  .nav-link:hover::before,
+  .nav-link:focus-visible::before {
+    transform: translateY(0%);
+  }
+
+  .nav-link[data-active='true'] {
+    color: #05000f;
+  }
+
+  .nav-link[data-active='true']::before {
+    transform: translateY(0%);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .nav-link {
+      transition: none;
+    }
+
+    .nav-link::before {
+      transition: none;
+    }
+  }
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -95,7 +95,7 @@ export default function Header() {
               <Link
                 key={link.href}
                 href={link.href}
-                className="rounded-full px-3 py-2 text-brand-pink transition hover:bg-brand-pink/15 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/60"
+                className="nav-link inline-flex items-center justify-center rounded-full px-3 py-2 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950"
               >
                 {link.label}
               </Link>

--- a/components/nav/MegaMenu.tsx
+++ b/components/nav/MegaMenu.tsx
@@ -153,16 +153,13 @@ function DesktopMegaMenu({ onNavigate }: { onNavigate?: () => void }) {
             handleOpen()
           }
         }}
-        className={`inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/60 ${
-          open
-            ? 'bg-brand-pink/20 text-white'
-            : 'text-brand-pink/90 hover:bg-brand-pink/15 hover:text-white'
-        }`}
+        data-active={open}
+        className="nav-link inline-flex items-center gap-2 rounded-full px-3 py-2 text-sm font-semibold transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950"
       >
-        <Sparkles className="h-4 w-4" aria-hidden />
-        Categorías
+        <Sparkles className="relative z-10 h-4 w-4" aria-hidden />
+        <span className="relative z-10">Categorías</span>
         <ChevronDown
-          className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`}
+          className={`relative z-10 h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`}
           aria-hidden
         />
       </button>


### PR DESCRIPTION
## Summary
- add a reusable nav-link style with animated fill and accessible focus handling
- update the mega menu trigger button to adopt the new nav-link styling and ensure icon layering
- apply the nav-link styling to primary header links for consistent hover and focus behavior

## Testing
- npm run lint *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db5713193c83219dabc78e0d9440a4