### PR TITLE
Restyle header icon buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -60,6 +60,18 @@
     transform: translateY(1px);
   }
 
+  .icon-button {
+    @apply inline-flex items-center justify-center rounded-full p-2 text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black;
+  }
+
+  .icon-button:hover {
+    @apply text-brand-pink;
+  }
+
+  .icon-button:focus-visible {
+    @apply text-white;
+  }
+
   .btn-gradient {
     @apply inline-flex items-center justify-center gap-2 rounded-full px-6 py-3 text-base font-semibold text-white transition duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2;
     background-image: var(--grad);

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -93,7 +93,7 @@ export default function Header() {
             <button
               type="button"
               onClick={openSearch}
-              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/10 text-brand-pink transition hover:border-brand-pink/60 hover:bg-white/20 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70 md:w-auto md:px-3"
+              className="icon-button"
               aria-label="Abrir buscador"
             >
               <Search className="h-4 w-4" aria-hidden />
@@ -102,7 +102,7 @@ export default function Header() {
 
             <Link
               href="/carrito"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/10 text-brand-pink transition hover:border-brand-pink/60 hover:bg-white/20 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70 md:w-auto md:px-3"
+              className="icon-button"
               aria-label="Abrir carrito"
             >
               <ShoppingBag className="h-4 w-4" aria-hidden />
@@ -112,7 +112,7 @@ export default function Header() {
             <button
               type="button"
               onClick={openChat}
-              className="btn-primary h-10 px-5"
+              className="icon-button"
               aria-label="Abrir asistente"
             >
               <MessageCircle className="h-4 w-4" aria-hidden />
@@ -122,7 +122,7 @@ export default function Header() {
             <button
               type="button"
               aria-label={menuOpen ? 'Cerrar menú' : 'Abrir menú'}
-              className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/10 text-brand-pink transition hover:border-brand-pink/60 hover:bg-white/20 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70 md:hidden"
+              className="icon-button md:hidden"
               onClick={toggleMenu}
             >
               {menuOpen ? <X className="h-5 w-5" aria-hidden /> : <Menu className="h-5 w-5" aria-hidden />}


### PR DESCRIPTION
## Summary
- introduce a reusable `.icon-button` utility for flat icon actions with accessible focus rings
- restyle header search, cart, chat, and menu triggers to use the new flat icon treatment

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68db6261dde883218f8aeacf85c68cb1