### PR TITLE
Fix lucide icon import in MegaMenu

### DIFF
--- a/components/nav/MegaMenu.tsx
+++ b/components/nav/MegaMenu.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ChevronRight } from 'lucide-react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
 
 import { megaMenuConfig } from '@/data/mega-menu.config'
 import type { MegaMenuLink, MegaMenuTab } from '@/data/mega-menu.config'


### PR DESCRIPTION
## Summary
- update MegaMenu component to import both ChevronDown and ChevronRight from lucide-react

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc2822d4cc832193691e9143e0eaab