### PR TITLE
Add rotating header promo banner messages

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -54,6 +54,24 @@
     url('https://fonts.gstatic.com/s/archivo/v25/k3k6o8UDI-1M0wlSV9XAw6lQkqWY8Q82sJaRE-NWIDdgffTT0zRp8A.ttf') format('truetype');
 }
 
+@font-face {
+  font-family: 'Space Grotesk';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: local('Space Grotesk Medium'), local('SpaceGrotesk-Medium'),
+    url('https://fonts.gstatic.com/s/spacegrotesk/v22/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj7aUUsj.ttf') format('truetype');
+}
+
+@font-face {
+  font-family: 'Space Grotesk';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: local('Space Grotesk SemiBold'), local('SpaceGrotesk-SemiBold'),
+    url('https://fonts.gstatic.com/s/spacegrotesk/v22/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj42Vksj.ttf') format('truetype');
+}
+
 @layer base {
   html {
     font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -99,10 +117,12 @@
     @apply text-white;
   }
 
-  .font-promo {
-    font-family: 'Archivo', 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    letter-spacing: 0.18em;
+  .promo-rotator-text {
+    font-family: 'Space Grotesk', 'Archivo', 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+      sans-serif;
+    letter-spacing: 0.22em;
     text-transform: uppercase;
+    font-weight: 600;
   }
 
   .btn-gradient {


### PR DESCRIPTION
## Summary
- rotate the header promo banner through a list of messages with animated transitions and mobile-aware filtering
- introduce the Space Grotesk promo typography class for banner text and CTA styling

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dc2b880d8483218d9f68cb114c0f9c