### PR TITLE
Refactor mobile mega menu navigation flow

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -8,6 +8,7 @@ import { Menu, MessageCircle, Search, ShoppingBag, X } from 'lucide-react'
 
 import SearchOverlay from './header/SearchOverlay'
 import PersonaMegaMenu from './nav/PersonaMegaMenu'
+import MegaMenu from './nav/MegaMenu'
 import { openChatAssistant } from '@/lib/chat-assistant'
 
 const MotionWrapper: any = motion.div
@@ -297,21 +298,7 @@ export default function Header() {
                 <div className="relative flex-1 overflow-hidden">
                   <div className="h-full overflow-y-auto px-4 pb-10">
                     <nav className="space-y-6">
-                      <PersonaMegaMenu
-                        personaFacet="him"
-                        variant="mobile"
-                        onNavigate={() => setMenuOpen(false)}
-                      />
-                      <PersonaMegaMenu
-                        personaFacet="her"
-                        variant="mobile"
-                        onNavigate={() => setMenuOpen(false)}
-                      />
-                      <PersonaMegaMenu
-                        personaFacet="couples"
-                        variant="mobile"
-                        onNavigate={() => setMenuOpen(false)}
-                      />
+                      <MegaMenu variant="mobile" onNavigate={() => setMenuOpen(false)} />
                     </nav>
                   </div>
                   <div


### PR DESCRIPTION
## Summary
- replace the mobile mega menu accordion with a root/persona view state that shows only the top personas
- add a sliding transition with a back control when drilling into persona subcategories
- preserve tracking on CTA and column links within the new layout while removing unused dropdown icons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc2d6acacc8321936fcbcb16a23dea