### PR TITLE
Update typography stack to Manrope and Cormorant Garamond

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -18,63 +18,9 @@
   --border-strong: rgba(236, 208, 255, 0.45);
 }
 
-@font-face {
-  font-family: 'Inter';
-  font-style: normal;
-  font-weight: 400 900;
-  font-display: swap;
-  src: local('Inter'), local('Inter Regular'),
-    url('https://fonts.gstatic.com/s/inter/v20/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2') format('woff2');
-}
-
-@font-face {
-  font-family: 'Archivo';
-  font-style: normal;
-  font-weight: 500;
-  font-display: swap;
-  src: local('Archivo Medium'), local('Archivo-Medium'),
-    url('https://fonts.gstatic.com/s/archivo/v25/k3k6o8UDI-1M0wlSV9XAw6lQkqWY8Q82sJaRE-NWIDdgffTTBjNp8A.ttf') format('truetype');
-}
-
-@font-face {
-  font-family: 'Archivo';
-  font-style: normal;
-  font-weight: 600;
-  font-display: swap;
-  src: local('Archivo SemiBold'), local('Archivo-SemiBold'),
-    url('https://fonts.gstatic.com/s/archivo/v25/k3k6o8UDI-1M0wlSV9XAw6lQkqWY8Q82sJaRE-NWIDdgffTT6jRp8A.ttf') format('truetype');
-}
-
-@font-face {
-  font-family: 'Archivo';
-  font-style: normal;
-  font-weight: 700;
-  font-display: swap;
-  src: local('Archivo Bold'), local('Archivo-Bold'),
-    url('https://fonts.gstatic.com/s/archivo/v25/k3k6o8UDI-1M0wlSV9XAw6lQkqWY8Q82sJaRE-NWIDdgffTT0zRp8A.ttf') format('truetype');
-}
-
-@font-face {
-  font-family: 'Space Grotesk';
-  font-style: normal;
-  font-weight: 500;
-  font-display: swap;
-  src: local('Space Grotesk Medium'), local('SpaceGrotesk-Medium'),
-    url('https://fonts.gstatic.com/s/spacegrotesk/v22/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj7aUUsj.ttf') format('truetype');
-}
-
-@font-face {
-  font-family: 'Space Grotesk';
-  font-style: normal;
-  font-weight: 600;
-  font-display: swap;
-  src: local('Space Grotesk SemiBold'), local('SpaceGrotesk-SemiBold'),
-    url('https://fonts.gstatic.com/s/spacegrotesk/v22/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj42Vksj.ttf') format('truetype');
-}
-
 @layer base {
   html {
-    font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    font-family: var(--font-sans), ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   }
   body {
     background-color: var(--background);
@@ -118,9 +64,8 @@
   }
 
   .promo-rotator-text {
-    font-family: 'Space Grotesk', 'Archivo', 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
-      sans-serif;
-    letter-spacing: 0.22em;
+    font-family: var(--font-sans), ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    letter-spacing: 0.2em;
     text-transform: uppercase;
     font-weight: 600;
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import './globals.css'
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
 import Script from 'next/script'
-import { Montserrat } from 'next/font/google'
+import { Cormorant_Garamond, Manrope } from 'next/font/google'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import { ChatBubble } from '@/components/ChatBubble'
@@ -11,9 +11,16 @@ import Tracker from './Tracker'
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL
 
-const montserrat = Montserrat({
+const manrope = Manrope({
   subsets: ['latin'],
-  weight: ['700', '800'],
+  weight: ['300', '400', '500', '600'],
+  display: 'swap',
+  variable: '--font-sans'
+})
+
+const cormorantGaramond = Cormorant_Garamond({
+  subsets: ['latin'],
+  weight: ['500', '600'],
   display: 'swap',
   variable: '--font-heading'
 })
@@ -46,11 +53,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           crossOrigin="anonymous"
         />
         <link
-          rel="preload"
-          as="font"
-          type="font/woff2"
-          href="https://fonts.gstatic.com/s/inter/v20/UcC73FwrK3iLTeHuS_nVMrMxCp50SjIa1ZL7.woff2"
-          crossOrigin="anonymous"
+          rel="preconnect"
+          href="https://fonts.googleapis.com"
         />
         {gaId && (
           <>
@@ -78,7 +82,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <link rel="preconnect" href="https://plausible.io" />
         )}
       </head>
-      <body className={`${montserrat.variable} min-h-screen bg-white text-neutral-900 antialiased`}>
+      <body className={`${manrope.variable} ${cormorantGaramond.variable} min-h-screen bg-white text-neutral-900 antialiased`}>
         <Suspense fallback={null}>
           <Tracker />
         </Suspense>

--- a/components/home/CategoryCarousel.tsx
+++ b/components/home/CategoryCarousel.tsx
@@ -74,7 +74,7 @@ export function CategoryCard({
           </div>
         )}
         <div className="flex flex-1 flex-col gap-1 px-4 pb-6 pt-4">
-          <h3 className="font-heading text-lg font-extrabold uppercase text-neutral-900">{category.label}</h3>
+          <h3 className="font-heading text-lg font-semibold uppercase text-neutral-900">{category.label}</h3>
           <p className="truncate text-xs font-semibold uppercase tracking-[0.08em] text-neutral-600">{category.subtitle}</p>
           <p className="truncate text-xs font-semibold uppercase text-neutral-600">{category.description}</p>
         </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,8 +9,8 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter', ...defaultTheme.fontFamily.sans],
-        heading: ['var(--font-heading)', 'Montserrat', ...defaultTheme.fontFamily.sans]
+        sans: ['var(--font-sans)', ...defaultTheme.fontFamily.sans],
+        heading: ['var(--font-heading)', ...defaultTheme.fontFamily.serif]
       },
       colors: {
         background: 'var(--background)',


### PR DESCRIPTION
## Summary
- configure Manrope and Cormorant Garamond with next/font and expose variables on the layout
- simplify global styles by removing manual @font-face rules and wiring var-based families
- point Tailwind font families to the new variables and align heading weights in the category carousel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc3e3db9c48321bf91bc7b08b31807