### PR TITLE
Improve NavMegaMenu aria associations and focus behavior

### DIFF
--- a/components/nav/MegaMenu.tsx
+++ b/components/nav/MegaMenu.tsx
@@ -151,14 +151,22 @@ function DesktopMegaMenu({
     return tabs.find((tab) => tab.id === currentTabId) ?? tabs[0]
   }, [tabs, currentTabId])
 
+  const activePanelId = activeTab ? `${menuId}-${activeTab.id}` : ''
+  const panelLabelledBy = [activeTrigger?.id, activeTab ? `mega-tab-${activeTab.id}` : '']
+    .filter(Boolean)
+    .join(' ') || undefined
+
   useEffect(() => {
     if (!open) return
     if (typeof document === 'undefined') return
     if (!activeTrigger) return
     if (document.activeElement !== activeTrigger) return
 
-    const focusable = resolvedMenuRef.current?.querySelector<HTMLElement>('button, a')
-    focusable?.focus({ preventScroll: true })
+    const focusTarget =
+      resolvedMenuRef.current?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]') ??
+      resolvedMenuRef.current?.querySelector<HTMLElement>('a, button')
+
+    focusTarget?.focus({ preventScroll: true })
   }, [open, activeTrigger, activeTab, resolvedMenuRef])
 
   if (!hasTabs) {
@@ -206,7 +214,7 @@ function DesktopMegaMenu({
             <div className="pointer-events-auto w-full max-w-7xl px-4">
               <motion.div
                 ref={resolvedMenuRef}
-                id={menuId}
+                id={`${menuId}-container`}
                 aria-hidden={!open}
                 className="max-h-[calc(100vh-6rem)] overflow-y-auto rounded-3xl bg-neutral-950 p-8 text-sm text-white shadow-2xl md:p-10"
                 variants={contentWrapperVariants}
@@ -220,6 +228,7 @@ function DesktopMegaMenu({
                       >
                         {tabs.map((tab) => {
                           const isActive = tab.id === activeTab.id
+                          const tabPanelId = `${menuId}-${tab.id}`
                           return (
                             <motion.li key={tab.id} variants={fadeInUpVariants}>
                               <button
@@ -227,7 +236,7 @@ function DesktopMegaMenu({
                                 role="tab"
                                 id={`mega-tab-${tab.id}`}
                                 aria-selected={isActive}
-                                aria-controls={`mega-panel-${tab.id}`}
+                                aria-controls={tabPanelId}
                                 className={`px-0 py-1 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-pink ${
                                   isActive ? 'text-brand-pink' : 'text-neutral-300 hover:text-brand-pink'
                                 }`}
@@ -272,9 +281,9 @@ function DesktopMegaMenu({
                   </motion.ul>
 
                   <motion.div
-                    id={`mega-panel-${activeTab.id}`}
+                    id={activePanelId}
                     role="tabpanel"
-                    aria-labelledby={`mega-tab-${activeTab.id}`}
+                    aria-labelledby={panelLabelledBy}
                     className="grid gap-6 md:grid-cols-3"
                     variants={contentWrapperVariants}
                   >

--- a/components/nav/NavMegaMenu.tsx
+++ b/components/nav/NavMegaMenu.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import type { FocusEvent as ReactFocusEvent, MouseEvent as ReactMouseEvent } from 'react'
 
 import MegaMenu from './MegaMenu'
@@ -22,6 +22,12 @@ export default function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
   const [activeTabId, setActiveTabId] = useState<string>('')
   const [panelTop, setPanelTop] = useState(0)
 
+  const reactId = useId()
+  const menuBaseId = useMemo(
+    () => `nav-mega-menu-${reactId.replace(/:/g, '-')}`,
+    [reactId]
+  )
+
   const personaTabs = useMemo(() => {
     return PERSONA_ORDER.map((facet) =>
       megaMenuConfig.tabs.find((tab) => tab.personaFacet === facet) ?? null
@@ -29,7 +35,7 @@ export default function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
   }, [])
 
   const hasTabs = personaTabs.length > 0
-  const menuId = 'nav-mega-menu-panel'
+  const menuId = `${menuBaseId}-panel`
   const activeTrigger = activeTabId ? triggerRefs.current[activeTabId] ?? null : null
 
   useEffect(() => {
@@ -174,6 +180,7 @@ export default function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
     >
       {personaTabs.map((tab) => {
         const isExpanded = open && activeTabId === tab.id
+        const panelId = `${menuId}-${tab.id}`
         return (
           <button
             key={tab.id}
@@ -183,13 +190,14 @@ export default function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
             type="button"
             aria-haspopup="true"
             aria-expanded={isExpanded}
-            aria-controls={menuId}
+            aria-controls={panelId}
             onMouseEnter={() => handleOpenForTab(tab.id)}
             onMouseLeave={handleMouseLeave}
             onFocus={() => handleOpenForTab(tab.id)}
             onBlur={handleBlur}
             onClick={() => handleTriggerClick(tab.id)}
             data-active={isExpanded}
+            id={`${menuBaseId}-trigger-${tab.id}`}
             className="nav-link inline-flex items-center justify-center rounded-full px-5 py-3 text-lg font-semibold uppercase transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-pink/70 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950"
           >
             <span className="relative z-10">{tab.label}</span>


### PR DESCRIPTION
## Summary
- ensure the nav mega menu triggers generate stable ids and point aria-controls to their matching panels
- update the desktop mega menu to focus internal controls on keyboard open and expose matching panel ids/labels for accessibility

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dca4a3cfdc8321ae79daa6ce4a453c